### PR TITLE
Matoran eyes brain color

### DIFF
--- a/src/components/CharacterScene/DiminishedMatoranModel.tsx
+++ b/src/components/CharacterScene/DiminishedMatoranModel.tsx
@@ -78,7 +78,9 @@ export function DiminishedMatoranModel({ matoran }: { matoran: BaseMatoran }) {
       let standard = getStandardPlasticMaterial(color);
 
       const needsEmissive =
-        original.emissive && (original.emissiveIntensity ?? 0) > 0;
+        materialName === 'GlowingEyes' &&
+        original.emissive &&
+        (original.emissiveIntensity ?? 0) > 0;
       const needsTransparent = original.transparent;
 
       if (needsEmissive || needsTransparent) {


### PR DESCRIPTION
Update Diminished Matoran glowing eyes emissive color to match the configured eye color.

Previously, the `GlowingEyes` material's emissive color was copied directly from the original GLB model, preventing it from changing dynamically with the character's eye/brain color. This change ensures the glow color correctly reflects the chosen eye color.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-662197d2-7b56-4c34-8a7b-9e898ae30b46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-662197d2-7b56-4c34-8a7b-9e898ae30b46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

