### PR TITLE
Docker test timeout

### DIFF
--- a/e2e/battle/flow.spec.ts
+++ b/e2e/battle/flow.spec.ts
@@ -48,9 +48,9 @@ test.describe('Battle Flow', () => {
     await page.locator('.encounter button.confirm-button').first().click();
 
     await page.locator('h1.title').waitFor({ state: 'visible', timeout: 5000 });
-    await page.waitForTimeout(5000);
-
     const teamSelector = page.locator('.battle-prep__team-selector .character-card');
+    await teamSelector.first().waitFor({ state: 'visible', timeout: 20000 });
+
     await teamSelector.nth(0).click();
     await teamSelector.nth(1).click();
     await teamSelector.nth(2).click();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,6 +34,13 @@ export default defineConfig({
   /* Snapshot path template - different for CI vs local */
   snapshotPathTemplate,
 
+  /* Timeouts: CI/Docker are slower (no GPU, software WebGL) - use higher limits */
+  timeout: isCI ? 90_000 : 30_000,
+  expect: {
+    timeout: isCI ? 30_000 : 5_000,
+  },
+  globalTimeout: isCI ? 45 * 60 * 1000 : undefined,
+
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
@@ -79,6 +86,6 @@ export default defineConfig({
     command: 'yarn dev',
     url: 'http://localhost:5173',
     reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
+    timeout: isCI ? 180_000 : 120_000,
   },
 });


### PR DESCRIPTION
Adjust Playwright timeouts and waits to prevent e2e test failures in CI/Docker.

CI/Docker environments run slower due to software WebGL and limited resources, causing existing timeouts tuned for local development to be insufficient. This PR increases various Playwright timeouts and refines specific waits in helper functions and a test file to accommodate these performance differences, ensuring tests pass reliably in CI without affecting local run times.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-1d295eca-d09e-45b5-af1c-86223aac9cd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1d295eca-d09e-45b5-af1c-86223aac9cd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

