### PR TITLE
Combat utils undefined self

### DIFF
--- a/src/services/combatUtils.ts
+++ b/src/services/combatUtils.ts
@@ -463,7 +463,7 @@ export function queueCombatRound(
         (d) => d.type === 'CONFUSION' && d.durationRemaining > 0
       );
       const effectiveOpponentList = isConfused
-        ? actorList.filter((t) => t.hp > 0 && t.id !== self.id)
+        ? actorList.filter((t) => t.hp > 0 && t.id !== actor.id)
         : opponentList;
 
       let targets = effectiveOpponentList.filter((t) => t.hp > 0);


### PR DESCRIPTION
Replace `self.id` with `actor.id` to fix a TypeScript error where `self` was possibly `undefined`.

The `self` variable was reassigned after an initial null check, causing TypeScript to lose its type narrowing. Since `actor` and `self` refer to the same combatant, using `actor.id` resolves the type error without changing the logic.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-46b5948f-6405-49a6-a1be-dc5f5029fc68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-46b5948f-6405-49a6-a1be-dc5f5029fc68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

