### PR TITLE
Bugfix: double quest assignment

### DIFF
--- a/src/components/AvailableQuests/index.scss
+++ b/src/components/AvailableQuests/index.scss
@@ -61,6 +61,12 @@
       border-color: #f44336;
       color: #ffc1c1;
     }
+
+    &.busy {
+      background-color: #3a2d1d;
+      border-color: #ff9800;
+      color: #ffe0b2;
+    }
   }
 
   &__rewards {

--- a/src/components/AvailableQuests/index.tsx
+++ b/src/components/AvailableQuests/index.tsx
@@ -30,9 +30,15 @@ export const AvailableQuests: React.FC<AvailableQuestsProps> = ({
 }) => {
   const available = getAvailableQuests(allQuests, completedQuestIds, activeQuestIds);
 
+  /** Characters must exist, meet level, and NOT be on another quest */
   const hasMatoran = (requiredIds: string[] = [], minLevel: number = 1) =>
     requiredIds.every((id) =>
-      recruitedCharacters.some((m) => m.id === id && getLevelFromExp(m.exp) >= minLevel)
+      recruitedCharacters.some(
+        (m) =>
+          m.id === id &&
+          getLevelFromExp(m.exp) >= minLevel &&
+          !m.quest /* not already on a quest */
+      )
     );
 
   const hasItems = (items: QuestItemRequirement[] = []) =>
@@ -69,12 +75,14 @@ export const AvailableQuests: React.FC<AvailableQuestsProps> = ({
                   <strong>Matoran:</strong>
                   <br />
                   {quest.requirements.matoran?.map((id) => {
-                    const has = recruitedCharacters.some(
-                      (m) =>
-                        m.id === id && getLevelFromExp(m.exp) >= (quest.requirements.minLevel ?? 1)
-                    );
+                    const matoran = recruitedCharacters.find((m) => m.id === id);
+                    const levelMet =
+                      matoran && getLevelFromExp(matoran.exp) >= (quest.requirements.minLevel ?? 1);
+                    const available = levelMet && !matoran?.quest;
+                    const busy = levelMet && matoran?.quest;
+                    const status = available ? 'met' : busy ? 'busy' : 'missing';
                     return (
-                      <span key={id} className={`requirement-chip ${has ? 'met' : 'missing'}`}>
+                      <span key={id} className={`requirement-chip ${status}`} title={busy ? 'On another quest' : undefined}>
                         {MATORAN_DEX[id].name}
                       </span>
                     );

--- a/src/hooks/useQuestState.tsx
+++ b/src/hooks/useQuestState.tsx
@@ -41,6 +41,13 @@ export const useQuestState = ({
   const [completedQuests, setCompletedQuestIds] = useState<string[]>(initialCompleted);
 
   const startQuest = (quest: Quest, assignedMatoran: RecruitedCharacterData['id'][]) => {
+    // Guard: do not assign quest to characters who already have an ongoing quest
+    const busy = assignedMatoran.filter((id) => {
+      const char = characters.find((c) => c.id === id);
+      return char?.quest;
+    });
+    if (busy.length > 0) return;
+
     const now = getCurrentTimestamp();
     const endsAt = now + (getDebugMode() ? 1 : quest.durationSeconds);
 


### PR DESCRIPTION
Prevent assigning new quests to characters already on a quest and update the UI to reflect this.

This PR addresses issue #35 by adding checks to prevent characters with ongoing quests from being assigned new ones, both in the UI and in the `startQuest` logic. It also introduces a "busy" state for characters in the `AvailableQuests` component.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-c3e3b57d-e6e3-4632-81f1-4984b8084bbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3e3b57d-e6e3-4632-81f1-4984b8084bbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

