### PR TITLE
Scene unmount visual glitch

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -129,8 +129,7 @@ export async function waitForCanvas(page: Page, timeout = 10000) {
   await page.waitForSelector('canvas', { timeout, state: 'visible' });
 
   // Brief buffer for WebGL to render the first frame
-  const isCI = !!process.env.CI || !!process.env.PLAYWRIGHT_DOCKER;
-  await page.waitForTimeout(isCI ? 2000 : 500);
+  await page.waitForTimeout(500);
 }
 
 /**

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -129,7 +129,8 @@ export async function waitForCanvas(page: Page, timeout = 10000) {
   await page.waitForSelector('canvas', { timeout, state: 'visible' });
 
   // Brief buffer for WebGL to render the first frame
-  await page.waitForTimeout(500);
+  const isCI = !!process.env.CI || !!process.env.PLAYWRIGHT_DOCKER;
+  await page.waitForTimeout(isCI ? 6000 : 3000);
 }
 
 /**

--- a/src/components/CharacterScene/index.tsx
+++ b/src/components/CharacterScene/index.tsx
@@ -94,7 +94,8 @@ function SceneReadyNotifier() {
   const { setSceneReady } = useSceneCanvas();
   useEffect(() => {
     setSceneReady(true);
-    return () => setSceneReady(false);
+    // Don't set false on unmount - parent handles that when changing scenes.
+    // Clearing here can hide the canvas if Suspense re-shows fallback or Strict Mode double-mounts.
   }, [setSceneReady]);
   return null;
 }

--- a/src/components/CharacterScene/index.tsx
+++ b/src/components/CharacterScene/index.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useEffect, useRef, useState } from 'react';
 import { Environment, PresentationControls } from '@react-three/drei';
 import { useThree } from '@react-three/fiber';
+import { useSceneCanvas } from '../../hooks/useSceneCanvas';
 import { EffectComposer, SSAO, SelectiveBloom } from '@react-three/postprocessing';
 import { BlendFunction } from 'postprocessing';
 import { Object3D } from 'three';
@@ -85,6 +86,19 @@ function CharacterFraming() {
   return null;
 }
 
+/**
+ * Signals to the canvas context when the character model has finished loading.
+ * Renders inside Suspense so it only mounts after CharacterModel resolves.
+ */
+function SceneReadyNotifier() {
+  const { setSceneReady } = useSceneCanvas();
+  useEffect(() => {
+    setSceneReady(true);
+    return () => setSceneReady(false);
+  }, [setSceneReady]);
+  return null;
+}
+
 export function CharacterScene({ matoran }: { matoran: BaseMatoran & RecruitedCharacterData }) {
   const characterRootRef = useRef<Object3D>(null);
   const [lightsForBloom, setLightsForBloom] = useState<Object3D[]>([]);
@@ -120,6 +134,7 @@ export function CharacterScene({ matoran }: { matoran: BaseMatoran & RecruitedCh
         >
           <Suspense fallback={null}>
             <CharacterModel matoran={matoran} />
+            <SceneReadyNotifier />
           </Suspense>
         </PresentationControls>
       </group>

--- a/src/context/Canvas.tsx
+++ b/src/context/Canvas.tsx
@@ -18,6 +18,7 @@ function SetSRGBColorSpace() {
 
 export const SceneCanvasProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [scene, setScene] = useState<React.ReactNode>(null);
+  const [sceneReady, setSceneReady] = useState(false);
   const [target, setTarget] = useState<HTMLElement | null>(null);
 
   const [debugMode] = useState(getDebugMode());
@@ -31,13 +32,14 @@ export const SceneCanvasProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
       // Optional: dynamically assign a route-based class
       el.className = `canvas-mount route-${location.pathname.replace(/\//g, '-')}`;
+      el.dataset.sceneReady = String(sceneReady);
 
       setTimeout(() => {}, 0);
     }
-  }, [location.pathname]);
+  }, [location.pathname, sceneReady]);
 
   return (
-    <SceneCanvasContext.Provider value={{ setScene, scene }}>
+    <SceneCanvasContext.Provider value={{ setScene, scene, sceneReady, setSceneReady }}>
       {children}
       {target &&
         createPortal(

--- a/src/hooks/useSceneCanvas.tsx
+++ b/src/hooks/useSceneCanvas.tsx
@@ -3,6 +3,8 @@ import { createContext, useContext } from 'react';
 interface SceneCanvasContextProps {
   setScene: (node: React.ReactNode) => void;
   scene: React.ReactNode;
+  sceneReady: boolean;
+  setSceneReady: (ready: boolean) => void;
 }
 
 export const SceneCanvasContext = createContext<SceneCanvasContextProps | null>(null);

--- a/src/pages/Battle/Arena.tsx
+++ b/src/pages/Battle/Arena.tsx
@@ -97,7 +97,7 @@ function ArenaReadyNotifier() {
   const { setSceneReady } = useSceneCanvas();
   useEffect(() => {
     setSceneReady(true);
-    return () => setSceneReady(false);
+    // Don't set false on unmount - Battle page cleanup handles that when changing scenes.
   }, [setSceneReady]);
   return null;
 }

--- a/src/pages/Battle/index.tsx
+++ b/src/pages/Battle/index.tsx
@@ -16,7 +16,7 @@ export const BattlePage: React.FC = () => {
   const navigate = useNavigate();
   const { battle, applyBattleRewards, completedQuests, collectedKrana } = useGame();
   const { currentEncounter, phase, currentWave, enemies, team } = battle;
-  const { setScene } = useSceneCanvas();
+  const { setScene, setSceneReady } = useSceneCanvas();
 
   const kranaRewards = useMemo(() => {
     if (
@@ -45,11 +45,16 @@ export const BattlePage: React.FC = () => {
 
   useEffect(() => {
     if (currentEncounter) {
+      setSceneReady(false);
       setScene(<Arena team={battle.team} enemies={battle.enemies} />);
     } else {
-      setScene(null); // or show something else
+      setScene(null);
     }
-  }, [setScene, currentEncounter, battle.team, battle.enemies, phase]);
+    return () => {
+      setSceneReady(false);
+      setScene(null);
+    };
+  }, [setScene, setSceneReady, currentEncounter, battle.team, battle.enemies, phase]);
 
   if (!currentEncounter) {
     return null;

--- a/src/pages/CharacterDetail/index.tsx
+++ b/src/pages/CharacterDetail/index.tsx
@@ -56,7 +56,11 @@ export const CharacterDetail: React.FC = () => {
       setSceneReady(false);
       setScene(null);
     };
-  }, [matoran, setScene, setSceneReady]);
+    // Only reset when switching characters (id). matoran gets new refs from game state updates
+    // (exp, quests, recruitedCharacters); depending on it would clear the scene repeatedly
+    // before SceneReadyNotifier can fire, leaving data-scene-ready stuck false.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally omit matoran
+  }, [id, setScene, setSceneReady]);
 
   // const combatantStats = useMemo(() => {
   //   return COMBATANT_DEX[matoran.id] || null;

--- a/src/pages/CharacterDetail/index.tsx
+++ b/src/pages/CharacterDetail/index.tsx
@@ -49,21 +49,12 @@ export const CharacterDetail: React.FC = () => {
   useEffect(() => {
     if (!matoran) return;
 
-    // Clear the scene first so the previous model is fully dismounted.
-    // Defer mounting the new scene so React commits the null state before we render the next model.
     setSceneReady(false);
-    setScene(null);
-
-    const rafId = requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        setScene(<CharacterScene matoran={matoran} />);
-      });
-    });
+    setScene(<CharacterScene matoran={matoran} />);
 
     return () => {
       setSceneReady(false);
       setScene(null);
-      cancelAnimationFrame(rafId);
     };
   }, [matoran, setScene, setSceneReady]);
 

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -32,6 +32,9 @@
     &.route--battle {
       display: block;
       z-index: -1;
+      &[data-scene-ready='false'] {
+        visibility: hidden;
+      }
     }
   }
 

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -25,6 +25,9 @@
       z-index: 1;
       left: calc(anchor(left) - 4rem);
       right: calc(anchor(right) - 4rem);
+      &[data-scene-ready='false'] {
+        visibility: hidden;
+      }
     }
     &.route--battle {
       display: block;


### PR DESCRIPTION
Properly dismount and remount the 3D scene to prevent the previous character model from briefly appearing when navigating between character detail pages.

The previous implementation would briefly show the old model before the new one loaded, as the scene was not fully cleared and the canvas remained visible. This PR introduces a coordinated dismount/remount process: the old scene is explicitly set to `null` and the canvas is hidden until the new model is fully loaded and ready, ensuring a clean transition.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-a3e224c4-ed70-489d-a1fc-590e14e35b81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a3e224c4-ed70-489d-a1fc-590e14e35b81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

