### PR TITLE
Rewards display issues

### DIFF
--- a/src/game/BattleRewards.spec.ts
+++ b/src/game/BattleRewards.spec.ts
@@ -277,5 +277,33 @@ describe('BattleRewards', () => {
 
       jest.spyOn(Math, 'random').mockRestore();
     });
+
+    test('does not award same krana twice when multiple enemies share element', () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0); // always succeed
+
+      const encounter = mockEncounter(
+        [
+          [
+            { id: 'tahnok', lvl: 20 },
+            { id: 'tahnok', lvl: 20 },
+            { id: 'tahnok', lvl: 20 },
+          ],
+        ],
+        [{ id: 'krana-ja-blue', chance: 1 }]
+      );
+      const rewards = computeKranaRewardsForBattle(
+        encounter,
+        BattlePhase.Victory,
+        0,
+        [],
+        completedQuests,
+        {}
+      );
+
+      expect(rewards).toHaveLength(1);
+      expect(rewards[0]).toEqual({ element: ElementTribe.Fire, kranaId: 'Ja' });
+
+      jest.spyOn(Math, 'random').mockRestore();
+    });
   });
 });

--- a/src/game/BattleRewards.ts
+++ b/src/game/BattleRewards.ts
@@ -143,14 +143,21 @@ export function computeKranaRewardsForBattle(
   if (!isKranaCollectionActive(completedQuests)) return [];
   const elements = getDefeatedEnemyElements(encounter, phase, currentWave, currentEnemies);
   const rewards: KranaReward[] = [];
+  const awardedThisBattle = new Set<string>();
   for (const element of elements) {
     if (!isKranaElement(element)) continue;
     const kranaLoot = getKranaLootForElement(encounter, element);
     let awarded: KranaReward | null = null;
     if (kranaLoot.length > 0) {
       for (const { element: el, kranaId, chance } of kranaLoot) {
-        if (!isKranaCollected(collectedKrana, el, kranaId) && Math.random() < chance) {
+        const key = `${el}:${kranaId}`;
+        if (
+          !isKranaCollected(collectedKrana, el, kranaId) &&
+          !awardedThisBattle.has(key) &&
+          Math.random() < chance
+        ) {
           awarded = { element: el, kranaId };
+          awardedThisBattle.add(key);
           break;
         }
       }

--- a/src/hooks/useGameLogic.tsx
+++ b/src/hooks/useGameLogic.tsx
@@ -140,9 +140,15 @@ export const useGameLogic = (): GameState => {
         );
       }
 
-      // Apply Krana: use pre-computed list from battle screen, or roll now if not provided.
+      // Apply Krana: use pre-computed list from battle screen when provided (so display and
+      // collection stay in sync). Only roll when kranaToApply was not passed at all.
+      const kranaExplicitlyProvided = params.kranaToApply !== undefined;
       let toApply: KranaReward[] = params.kranaToApply ?? [];
-      if (toApply.length === 0 && isKranaCollectionActive(completedQuests)) {
+      if (
+        !kranaExplicitlyProvided &&
+        toApply.length === 0 &&
+        isKranaCollectionActive(completedQuests)
+      ) {
         toApply = computeKranaRewardsForBattle(
           params.encounter,
           params.phase,


### PR DESCRIPTION
Fixes duplicate krana rewards and inconsistent display of collected krana.

When multiple enemies shared an element, each could award the same krana, leading to duplicates. Additionally, `applyBattleRewards` would re-roll krana even when an empty list was passed from the UI, causing a mismatch between what was shown and what was actually collected.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-7548a4e3-d413-4554-a1de-2cc33c282822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7548a4e3-d413-4554-a1de-2cc33c282822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

