### PR TITLE
Arena enemy labels

### DIFF
--- a/src/data/combat.ts
+++ b/src/data/combat.ts
@@ -342,8 +342,6 @@ export const COMBATANT_DEX: Record<string, CombatantTemplate> = {
   },
 };
 
-export const TEAM_POSITION_LABELS = ['Middle', 'Left', 'Right'];
-
 /** Krana drop ids by color: blue=Fire, orange=Water, red=Air, green=Stone, lime=Earth, white=Ice */
 const KRANA_BY_COLOR = {
   blue: [

--- a/src/hooks/useBattleState.tsx
+++ b/src/hooks/useBattleState.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react';
 import { Combatant, EnemyEncounter } from '../types/Combat';
 import { RecruitedCharacterData } from '../types/Matoran';
 import { getLevelFromExp } from '../game/Levelling';
-import { TEAM_POSITION_LABELS } from '../data/combat';
 import {
   generateCombatantStats,
   queueCombatRound,
@@ -116,7 +115,7 @@ export const useBattleState = (): BattleState => {
     setTeam([]);
     setEnemies(
       encounter!.waves[0].map(({ id, lvl }, index) =>
-        generateCombatantStats(`${id} ${TEAM_POSITION_LABELS[index]}`, id, lvl)
+        generateCombatantStats(`${id}-${index}`, id, lvl)
       )
     );
     setPhase(BattlePhase.Preparing);
@@ -142,7 +141,7 @@ export const useBattleState = (): BattleState => {
     // Load new enemies for the next wave
     setEnemies(
       currentEncounter.waves[nextWave].map(({ id, lvl }, index) =>
-        generateCombatantStats(`${id} ${TEAM_POSITION_LABELS[index]}`, id, lvl)
+        generateCombatantStats(`${id}-${index}`, id, lvl)
       )
     );
   };
@@ -173,7 +172,7 @@ export const useBattleState = (): BattleState => {
     setCurrentWave(0);
     setEnemies(
       currentEncounter!.waves[0].map(({ id, lvl }, index) =>
-        generateCombatantStats(`${id} ${TEAM_POSITION_LABELS[index]}`, id, lvl)
+        generateCombatantStats(`${id}-${index}`, id, lvl)
       )
     );
     setPhase(BattlePhase.Inprogress);

--- a/src/pages/Battle/Cards/Enemy.tsx
+++ b/src/pages/Battle/Cards/Enemy.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import { COMBATANT_DEX } from '../../../data/combat';
 import { Combatant } from '../../../types/Combat';
 import { DamagePopup } from './DamagePopup';
 
@@ -27,7 +26,7 @@ export function EnemyCard({ enemy }: { enemy: Combatant }) {
       key={enemy.id}
       className={`enemy-card element-${enemy.element}`}
     >
-      <div className="name">{COMBATANT_DEX[enemy.id]?.name || enemy.id}</div>
+      <div className="name">{enemy.name}</div>
       <div className="hp-bar">
         HP: {enemy.hp}/{enemy.maxHp}
         {damage && <DamagePopup damage={damage} direction="down" isHealing={false} />}

--- a/src/pages/Battle/InProgress.tsx
+++ b/src/pages/Battle/InProgress.tsx
@@ -24,9 +24,10 @@ export const BattleInProgress = () => {
           <div className="enemy-list">
             {enemies
               .toSorted((a, b) => {
-                const positionA = a.id.split(' ')[1];
-                const positionB = b.id.split(' ')[1];
-                return positionA.localeCompare(positionB);
+                const iA = parseInt(a.id.split('-').pop() ?? '0', 10);
+                const iB = parseInt(b.id.split('-').pop() ?? '0', 10);
+                const order = [1, 0, 2]; // left, middle, right
+                return order.indexOf(iA) - order.indexOf(iB);
               })
               .map((enemy, i) => (
                 <EnemyCard key={i} enemy={enemy} />

--- a/src/services/battleSimulation.spec.ts
+++ b/src/services/battleSimulation.spec.ts
@@ -4,7 +4,6 @@
  * mask powers incorrectly staying active across round boundaries.
  */
 import { Combatant, EnemyEncounter } from '../types/Combat';
-import { TEAM_POSITION_LABELS } from '../data/combat';
 import { ENCOUNTERS } from '../data/combat';
 import { Mask } from '../types/Matoran';
 import {
@@ -42,7 +41,7 @@ class BattleSimulator {
   constructor(team: Combatant[], encounter: EnemyEncounter, currentWave = 0) {
     this.team = cloneCombatants(team);
     this.enemies = encounter.waves[currentWave].map(({ id, lvl }, index) =>
-      generateCombatantStats(`${id} ${TEAM_POSITION_LABELS[index]}`, id, lvl)
+      generateCombatantStats(`${id}-${index}`, id, lvl)
     );
     this.currentWave = currentWave;
     this.encounter = encounter;
@@ -108,7 +107,7 @@ class BattleSimulator {
     this.team = decrementWaveCounters(this.team);
     this.currentWave++;
     this.enemies = this.encounter.waves[this.currentWave].map(({ id, lvl }, index) =>
-      generateCombatantStats(`${id} ${TEAM_POSITION_LABELS[index]}`, id, lvl)
+      generateCombatantStats(`${id}-${index}`, id, lvl)
     );
   }
 


### PR DESCRIPTION
Remove "Left", "Middle", and "Right" labels from enemy names in the arena visualization and enemy cards.

The position of the enemies in the visualization is sufficient to distinguish them, making the explicit position labels redundant and simplifying the UI. This involved updating enemy IDs to an index-based format (e.g., "Gahlok-0"), adjusting display logic, and updating related sorting and test files.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-d6baa16f-6c1e-43bd-8fad-9e4398e46583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d6baa16f-6c1e-43bd-8fad-9e4398e46583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

