### PR TITLE
Popover positioning logic

### DIFF
--- a/src/components/Tooltip/index.scss
+++ b/src/components/Tooltip/index.scss
@@ -1,22 +1,14 @@
 .tooltip {
-  position: relative; // For fallback absolute positioning of content
   display: inline-flex;
 
   &__trigger {
     display: inherit;
     cursor: inherit;
     outline: none;
-
-    // Anchor for CSS Anchor Positioning (Chrome 125+, Safari 18+)
-    anchor-name: --tooltip-anchor;
   }
 
+  // Content is rendered via portal to document.body - position/opacity/visibility via inline style
   &__content {
-    position: fixed;
-    position-anchor: --tooltip-anchor;
-    inset-area: block-start;
-    margin-block-end: 0.5rem;
-    position-try-fallbacks: flip-block, flip-inline;
     width: max-content;
     max-width: min(220px, 90vw);
     padding: 0.5rem 0.75rem;
@@ -26,36 +18,10 @@
     font-size: 0.8125rem;
     line-height: 1.35;
     box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.5));
-    z-index: 100;
-    opacity: 0;
-    visibility: hidden;
+    z-index: 10000;
+    pointer-events: none;
     transition:
       opacity 0.15s ease,
       visibility 0.15s ease;
-    pointer-events: none;
-  }
-
-  &:hover &__content,
-  &__trigger:focus-visible + &__content {
-    opacity: 1;
-    visibility: visible;
-  }
-
-  // Fallback for browsers without CSS Anchor Positioning
-  @supports not (anchor-name: --tooltip-anchor) {
-    &__trigger {
-      anchor-name: unset;
-    }
-
-    &__content {
-      position: absolute;
-      bottom: calc(100% + 0.5rem);
-      left: 50%;
-      transform: translateX(-50%);
-      position-anchor: unset;
-      inset-area: unset;
-      position-try-fallbacks: unset;
-      margin-block-end: unset;
-    }
   }
 }

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,4 +1,11 @@
+import { useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
 import './index.scss';
+
+const GAP = 8;
+const MAX_WIDTH = 220;
+const VIEWPORT_PADDING = 8;
 
 interface TooltipProps {
   /** Tooltip content. When undefined/null/empty, children render without tooltip (for conditional tooltips). */
@@ -7,26 +14,202 @@ interface TooltipProps {
   children: React.ReactNode;
 }
 
+function getScrollParents(element: HTMLElement): HTMLElement[] {
+  const parents: HTMLElement[] = [];
+  let current: HTMLElement | null = element;
+  while (current) {
+    const { overflow, overflowY, overflowX } = getComputedStyle(current);
+    const isScrollable =
+      overflow === 'auto' ||
+      overflow === 'scroll' ||
+      overflowY === 'auto' ||
+      overflowY === 'scroll' ||
+      overflowX === 'auto' ||
+      overflowX === 'scroll';
+    if (isScrollable && current !== document.body) {
+      parents.push(current);
+    }
+    current = current.parentElement;
+  }
+  return parents;
+}
+
 /**
  * General-purpose tooltip that works on hover (desktop) and focus (mobile, keyboard).
- * Uses CSS anchor positioning with position-try-fallbacks to avoid rendering off-screen.
- * Replaces title attributes for better mobile support.
+ * Renders via portal to escape overflow/transform ancestors. Uses JS positioning with
+ * automatic flip when there's insufficient viewport space.
  */
 export function Tooltip({ content, children }: TooltipProps) {
   const hasContent = content !== undefined && content !== null && content !== '';
+
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+  const tooltipId = useId();
+
+  const updatePosition = () => {
+    const trigger = triggerRef.current;
+    const tooltipEl = contentRef.current;
+    if (!trigger || !tooltipEl || !visible) return;
+
+    const triggerRect = trigger.getBoundingClientRect();
+    const tooltipRect = tooltipEl.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    const spaceAbove = triggerRect.top;
+    const spaceBelow = viewportHeight - triggerRect.bottom;
+    const spaceLeft = triggerRect.left;
+    const spaceRight = viewportWidth - triggerRect.right;
+
+    const tooltipWidth = Math.min(tooltipRect.width, MAX_WIDTH);
+    const tooltipHeight = tooltipRect.height;
+
+    type Placement = 'top' | 'bottom' | 'left' | 'right';
+
+    const placements: Placement[] = ['top', 'bottom', 'left', 'right'];
+    const requiredSpace: Record<Placement, { block: number; inline: number }> = {
+      top: { block: tooltipHeight + GAP, inline: tooltipWidth },
+      bottom: { block: tooltipHeight + GAP, inline: tooltipWidth },
+      left: { block: tooltipHeight, inline: tooltipWidth + GAP },
+      right: { block: tooltipHeight, inline: tooltipWidth + GAP },
+    };
+
+    let placement: Placement = 'top';
+    for (const p of placements) {
+      const { block, inline } = requiredSpace[p];
+      const hasBlock =
+        p === 'top'
+          ? spaceAbove >= block
+          : p === 'bottom'
+            ? spaceBelow >= block
+            : p === 'left'
+              ? spaceLeft >= inline
+              : spaceRight >= inline;
+      const hasInline =
+        p === 'top' || p === 'bottom'
+          ? spaceLeft >= inline / 2 && spaceRight >= inline / 2
+          : spaceAbove >= block / 2 && spaceBelow >= block / 2;
+      if (hasBlock && hasInline) {
+        placement = p;
+        break;
+      }
+    }
+
+    let top = 0;
+    let left = triggerRect.left + triggerRect.width / 2;
+
+    switch (placement) {
+      case 'top':
+        top = triggerRect.top - tooltipHeight - GAP;
+        break;
+      case 'bottom':
+        top = triggerRect.bottom + GAP;
+        break;
+      case 'left':
+        top = triggerRect.top + triggerRect.height / 2 - tooltipHeight / 2;
+        left = triggerRect.left - tooltipWidth - GAP;
+        break;
+      case 'right':
+        top = triggerRect.top + triggerRect.height / 2 - tooltipHeight / 2;
+        left = triggerRect.right + GAP;
+        break;
+      default:
+        top = triggerRect.top - tooltipHeight - GAP;
+    }
+
+    if (placement === 'top' || placement === 'bottom') {
+      left = triggerRect.left + triggerRect.width / 2 - tooltipWidth / 2;
+      left = Math.max(VIEWPORT_PADDING, Math.min(viewportWidth - tooltipWidth - VIEWPORT_PADDING, left));
+    } else {
+      top = Math.max(VIEWPORT_PADDING, Math.min(viewportHeight - tooltipHeight - VIEWPORT_PADDING, top));
+    }
+
+    setPosition({ top, left });
+  };
+
+  useLayoutEffect(() => {
+    if (!visible) return;
+    updatePosition();
+  }, [visible]);
+
+  useEffect(() => {
+    if (!visible) return;
+
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+
+    const handleScrollOrResize = () => updatePosition();
+    window.addEventListener('resize', handleScrollOrResize);
+    window.addEventListener('scroll', handleScrollOrResize, true);
+
+    const scrollParents = getScrollParents(trigger);
+    scrollParents.forEach((el) => el.addEventListener('scroll', handleScrollOrResize));
+
+    return () => {
+      window.removeEventListener('resize', handleScrollOrResize);
+      window.removeEventListener('scroll', handleScrollOrResize, true);
+      scrollParents.forEach((el) => el.removeEventListener('scroll', handleScrollOrResize));
+    };
+  }, [visible]);
+
+  const showTooltip = () => setVisible(true);
+  const hideTooltip = () => {
+    setVisible(false);
+    setPosition(null);
+  };
 
   if (!hasContent) {
     return <>{children}</>;
   }
 
   return (
-    <span className="tooltip">
-      <span className="tooltip__trigger" tabIndex={0}>
-        {children}
+    <>
+      <span className="tooltip">
+        <span
+          ref={triggerRef}
+          className="tooltip__trigger"
+          tabIndex={0}
+          onMouseEnter={showTooltip}
+          onMouseLeave={hideTooltip}
+          onFocus={showTooltip}
+          onBlur={hideTooltip}
+          aria-describedby={visible ? tooltipId : undefined}
+        >
+          {children}
+        </span>
       </span>
-      <span className="tooltip__content" role="tooltip">
-        {content}
-      </span>
-    </span>
+      {visible &&
+        createPortal(
+          <div
+            ref={contentRef}
+            id={tooltipId}
+            className="tooltip__content"
+            role="tooltip"
+            style={
+              position
+                ? {
+                    position: 'fixed',
+                    top: position.top,
+                    left: position.left,
+                    maxWidth: MAX_WIDTH,
+                    opacity: 1,
+                    visibility: 'visible',
+                  }
+                : {
+                    position: 'fixed',
+                    left: -9999,
+                    top: 0,
+                    opacity: 0,
+                    visibility: 'hidden' as const,
+                  }
+            }
+          >
+            {content}
+          </div>,
+          document.body
+        )}
+    </>
   );
 }


### PR DESCRIPTION
Implement a portal-based tooltip with JS positioning and flip logic to fix clipping and incorrect placement issues.

The previous tooltip implementation suffered from two main issues: it wasn't aware of available space, leading to clipping or incorrect placement near viewport edges, and it was affected by ancestor CSS properties like `overflow: hidden` or `transform`, causing the tooltip to be clipped or positioned incorrectly relative to its trigger. This PR addresses these by rendering the tooltip in a portal and using JavaScript to calculate its position, allowing it to escape ancestor styling and dynamically adjust its placement based on available viewport space.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-38082460-b0a3-46cc-8371-7dbe3c2ac5cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-38082460-b0a3-46cc-8371-7dbe3c2ac5cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

