### PR TITLE
Krana loot route visibility

### DIFF
--- a/e2e/battle/selector.spec.ts
+++ b/e2e/battle/selector.spec.ts
@@ -1,6 +1,15 @@
 import { test, expect } from '@playwright/test';
 import { enableTestMode, goto, INITIAL_GAME_STATE, setupGameState } from '../helpers';
 
+const ALL_KRANA_COLLECTED = {
+  Fire: ['Xa', 'Bo', 'Su', 'Za', 'Vu', 'Ja', 'Yo', 'Ca'],
+  Water: ['Xa', 'Bo', 'Su', 'Za', 'Vu', 'Ja', 'Yo', 'Ca'],
+  Air: ['Xa', 'Bo', 'Su', 'Za', 'Vu', 'Ja', 'Yo', 'Ca'],
+  Earth: ['Xa', 'Bo', 'Su', 'Za', 'Vu', 'Ja', 'Yo', 'Ca'],
+  Ice: ['Xa', 'Bo', 'Su', 'Za', 'Vu', 'Ja', 'Yo', 'Ca'],
+  Stone: ['Xa', 'Bo', 'Su', 'Za', 'Vu', 'Ja', 'Yo', 'Ca'],
+};
+
 test.describe('Battle Nav Item', () => {
   test('should display battle nav item if quest requirements are met', async ({ page }) => {
     await setupGameState(page, {
@@ -12,6 +21,18 @@ test.describe('Battle Nav Item', () => {
     await page.locator('.page-container').first().waitFor({ state: 'visible', timeout: 10000 });
 
     await expect(page).toHaveScreenshot({});
+  });
+
+  test('should hide battle nav item when no encounters have quest loot', async ({ page }) => {
+    await setupGameState(page, {
+      ...INITIAL_GAME_STATE,
+      completedQuests: ['bohrok_legend_of_krana'],
+      collectedKrana: ALL_KRANA_COLLECTED,
+    });
+    await goto(page, '/');
+
+    await page.locator('.nav-bar').waitFor({ state: 'visible', timeout: 10000 });
+    await expect(page.locator('nav a[href*="/battle"]')).not.toBeVisible();
   });
 });
 

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -1,8 +1,11 @@
+import { useMemo } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { useGame } from '../../context/Game';
 import { UserCircle2, Backpack, Settings, Map, Swords } from 'lucide-react';
 import { BattlePhase } from '../../hooks/useBattleState';
 import { areBattlesUnlocked } from '../../game/Progress';
+import { getVisibleEncounters } from '../../game/encounterVisibility';
+import { ENCOUNTERS } from '../../data/combat';
 import { CurrencyBar } from '../CurrencyBar';
 
 const shouldShowCurrencyBar = (pathname: string) => {
@@ -10,8 +13,14 @@ const shouldShowCurrencyBar = (pathname: string) => {
 };
 
 export const NavBar = ({ isPortrait }: { isPortrait: boolean }) => {
-  const { battle, completedQuests } = useGame();
+  const { battle, completedQuests, collectedKrana } = useGame();
   const { pathname } = useLocation();
+  const visibleEncounters = useMemo(
+    () => getVisibleEncounters(ENCOUNTERS, collectedKrana, completedQuests),
+    [collectedKrana, completedQuests]
+  );
+  const showBattleRoute =
+    areBattlesUnlocked(completedQuests) && visibleEncounters.length > 0;
 
   return (
     <div
@@ -28,7 +37,7 @@ export const NavBar = ({ isPortrait }: { isPortrait: boolean }) => {
     >
       {shouldShowCurrencyBar(pathname) && <CurrencyBar isPortrait={isPortrait} />}
       <nav className="nav-bar">
-        {areBattlesUnlocked(completedQuests) && (
+        {showBattleRoute && (
           <NavLink to="/battle" className="nav-item">
             <Swords />
             <label>Battle</label>


### PR DESCRIPTION
Hide the Battle navigation link when no encounters have uncollected quest loot.

---
<p><a href="https://cursor.com/agents?id=bc-229173cb-cc0c-473d-831d-ca6c31a39b0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-229173cb-cc0c-473d-831d-ca6c31a39b0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

