### PR TITLE
Characters tab persistence

### DIFF
--- a/src/pages/CharacterInventory/index.tsx
+++ b/src/pages/CharacterInventory/index.tsx
@@ -9,8 +9,10 @@ import { useGame } from '../../context/Game';
 import { MATORAN_DEX } from '../../data/matoran';
 import { QUESTS } from '../../data/quests';
 import { isMatoran, isToa } from '../../services/matoranUtils';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { Tabs } from '../../components/Tabs';
+
+const CHARACTERS_TAB_KEY = 'characters-tab';
 
 export const CharacterInventory: React.FC = () => {
   const { recruitedCharacters, buyableCharacters } = useGame();
@@ -23,24 +25,50 @@ export const CharacterInventory: React.FC = () => {
     return base;
   }, [recruitedCharacters]);
 
-  const [activeTab, setActiveTab] = useState<'matoran' | 'toa'>('matoran');
+  const [activeTab, setActiveTab] = useState<'matoran' | 'toa'>(() => {
+    try {
+      const stored = sessionStorage.getItem(CHARACTERS_TAB_KEY) as 'matoran' | 'toa' | null;
+      if (stored === 'matoran' || stored === 'toa') {
+        return stored;
+      }
+    } catch {
+      /* ignore storage errors */
+    }
+    return 'matoran';
+  });
+
+  const handleTabChange = useCallback(
+    (tab: string) => {
+      const value = tab as 'matoran' | 'toa';
+      setActiveTab(value);
+      try {
+        sessionStorage.setItem(CHARACTERS_TAB_KEY, value);
+      } catch {
+        /* ignore storage errors */
+      }
+    },
+    []
+  );
+
+  // If stored tab isn't available (e.g. toa tab hidden when no Toa recruited), fall back to matoran
+  const effectiveTab = tabs.includes(activeTab) ? activeTab : 'matoran';
 
   const characters = useMemo(() => {
     return recruitedCharacters.filter((matoran) => {
-      if (activeTab === 'matoran') {
+      if (effectiveTab === 'matoran') {
         return isMatoran(MATORAN_DEX[matoran.id]);
       }
       return isToa(MATORAN_DEX[matoran.id]);
     });
-  }, [recruitedCharacters, activeTab]);
+  }, [recruitedCharacters, effectiveTab]);
 
   return (
     <div className="page-container">
       <div className="character-inventory-tabs">
         <Tabs
           tabs={tabs}
-          activeTab={activeTab}
-          onTabChange={(tab: string) => setActiveTab(tab as 'matoran' | 'toa')}
+          activeTab={effectiveTab}
+          onTabChange={handleTabChange}
         />
       </div>
       <div className="character-grid">


### PR DESCRIPTION
Persist the selected tab on the characters page to restore the last filter (Matoran/Toa) when navigating back.

---
<p><a href="https://cursor.com/agents?id=bc-4dc1ed91-b64b-47ce-af0a-aeb5633028c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dc1ed91-b64b-47ce-af0a-aeb5633028c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

