### PR TITLE
Bohrok kal battle nav

### DIFF
--- a/e2e/battle/selector.spec.ts
+++ b/e2e/battle/selector.spec.ts
@@ -34,6 +34,17 @@ test.describe('Battle Nav Item', () => {
     await page.locator('.nav-bar').waitFor({ state: 'visible', timeout: 10000 });
     await expect(page.locator('nav a[href*="/battle"]')).not.toBeVisible();
   });
+
+  test('should hide battle nav item after Bohrok Kal are defeated', async ({ page }) => {
+    await setupGameState(page, {
+      ...INITIAL_GAME_STATE,
+      completedQuests: ['bohrok_legend_of_krana', 'bohrok_kal_final_confrontation'],
+    });
+    await goto(page, '/');
+
+    await page.locator('.nav-bar').waitFor({ state: 'visible', timeout: 10000 });
+    await expect(page.locator('nav a[href*="/battle"]')).not.toBeVisible();
+  });
 });
 
 test.describe('Battle Selector', () => {

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -5,6 +5,7 @@ import { UserCircle2, Backpack, Settings, Map, Swords } from 'lucide-react';
 import { BattlePhase } from '../../hooks/useBattleState';
 import { areBattlesUnlocked } from '../../game/Progress';
 import { getVisibleEncounters } from '../../game/encounterVisibility';
+import { BOHROK_KAL_FINAL_CONFRONTATION_QUEST_ID } from '../../game/nuvaSymbols';
 import { ENCOUNTERS } from '../../data/combat';
 import { CurrencyBar } from '../CurrencyBar';
 
@@ -19,8 +20,13 @@ export const NavBar = ({ isPortrait }: { isPortrait: boolean }) => {
     () => getVisibleEncounters(ENCOUNTERS, collectedKrana, completedQuests),
     [collectedKrana, completedQuests]
   );
+  const bohrokKalDefeated = completedQuests.includes(
+    BOHROK_KAL_FINAL_CONFRONTATION_QUEST_ID
+  );
   const showBattleRoute =
-    areBattlesUnlocked(completedQuests) && visibleEncounters.length > 0;
+    areBattlesUnlocked(completedQuests) &&
+    visibleEncounters.length > 0 &&
+    !bohrokKalDefeated;
 
   return (
     <div


### PR DESCRIPTION
Hide the battle navigation bar after the Bohrok Kal final confrontation quest is completed.

---
<p><a href="https://cursor.com/agents/bc-23c09f73-b014-4222-b055-023238ef910e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23c09f73-b014-4222-b055-023238ef910e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

