### PR TITLE
Lint warnings resolution

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'coverage'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/src/components/CharacterScene/index.tsx
+++ b/src/components/CharacterScene/index.tsx
@@ -5,7 +5,7 @@ import { EffectComposer, SSAO, SelectiveBloom } from '@react-three/postprocessin
 import { BlendFunction } from 'postprocessing';
 import { DirectionalLight, Mesh, Object3D } from 'three';
 
-import { useSettings } from '../../context/Settings';
+import { useSettings } from '../../context/useSettings';
 import { shouldEnableSelectiveBloom } from '../../utils/testMode';
 import { CYLINDER_RADIUS } from './BoundsCylinder';
 

--- a/src/components/MatoranAvatar/index.tsx
+++ b/src/components/MatoranAvatar/index.tsx
@@ -22,7 +22,7 @@ export function MatoranAvatar({
   const { colors } = matoran;
   const maskColor = useMemo(
     () => getEffectiveMaskColor(matoran, completedQuests),
-    [matoran.colors.mask, completedQuests]
+    [matoran, completedQuests]
   );
 
   const mask = useMemo(() => {

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import './index.scss';
@@ -48,7 +48,7 @@ export function Tooltip({ content, children }: TooltipProps) {
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
   const tooltipId = useId();
 
-  const updatePosition = () => {
+  const updatePosition = useCallback(() => {
     const trigger = triggerRef.current;
     const tooltipEl = contentRef.current;
     if (!trigger || !tooltipEl || !visible) return;
@@ -127,12 +127,12 @@ export function Tooltip({ content, children }: TooltipProps) {
     }
 
     setPosition({ top, left });
-  };
+  }, [visible]);
 
   useLayoutEffect(() => {
     if (!visible) return;
     updatePosition();
-  }, [visible]);
+  }, [visible, updatePosition]);
 
   useEffect(() => {
     if (!visible) return;
@@ -152,7 +152,7 @@ export function Tooltip({ content, children }: TooltipProps) {
       window.removeEventListener('scroll', handleScrollOrResize, true);
       scrollParents.forEach((el) => el.removeEventListener('scroll', handleScrollOrResize));
     };
-  }, [visible]);
+  }, [visible, updatePosition]);
 
   const showTooltip = () => setVisible(true);
   const hideTooltip = () => {

--- a/src/context/Canvas.tsx
+++ b/src/context/Canvas.tsx
@@ -5,7 +5,7 @@ import { useLocation } from 'react-router-dom';
 import { PCFSoftShadowMap, SRGBColorSpace } from 'three';
 import { SceneCanvasContext } from '../hooks/useSceneCanvas';
 import { Perf } from 'r3f-perf';
-import { useSettings } from './Settings';
+import { useSettings } from './useSettings';
 
 /** Set sRGB output once for the whole app so postprocessing and materials look correct. */
 function SetSRGBColorSpace() {

--- a/src/context/Settings.tsx
+++ b/src/context/Settings.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   getDebugMode,
   getShadowsEnabled,
@@ -6,20 +6,7 @@ import {
   saveShadowsEnabled,
 } from '../services/gamePersistence';
 
-export interface SettingsState {
-  debugMode: boolean;
-  setDebugMode: (value: boolean) => void;
-  shadowsEnabled: boolean;
-  setShadowsEnabled: (value: boolean) => void;
-}
-
-const SettingsContext = createContext<SettingsState | null>(null);
-
-export function useSettings() {
-  const ctx = useContext(SettingsContext);
-  if (!ctx) throw new Error('useSettings must be used within SettingsProvider');
-  return ctx;
-}
+import { SettingsContext } from './SettingsContext';
 
 export function SettingsProvider({ children }: { children: React.ReactNode }) {
   const [debugMode, setDebugModeState] = useState(getDebugMode);

--- a/src/context/SettingsContext.ts
+++ b/src/context/SettingsContext.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+export interface SettingsState {
+  debugMode: boolean;
+  setDebugMode: (value: boolean) => void;
+  shadowsEnabled: boolean;
+  setShadowsEnabled: (value: boolean) => void;
+}
+
+export const SettingsContext = createContext<SettingsState | null>(null);

--- a/src/context/useSettings.ts
+++ b/src/context/useSettings.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { SettingsContext } from './SettingsContext';
+
+export function useSettings() {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) throw new Error('useSettings must be used within SettingsProvider');
+  return ctx;
+}

--- a/src/data/matoran.ts
+++ b/src/data/matoran.ts
@@ -399,7 +399,7 @@ export const MATORAN_DEX: Record<string, BaseMatoran> = {
     },
     chronicleId: CHRONICLE_IDS.AHKMOU,
   },
-  : {
+  Kivi: {
     id: 'Kivi',
     name: 'Kivi',
     mask: Mask.Kaukau,

--- a/src/hooks/useNuvaMask.ts
+++ b/src/hooks/useNuvaMask.ts
@@ -107,7 +107,7 @@ export function useNuvaMask(
       masksParent.remove(clone);
       maskRef.current = null;
     };
-  }, [masksNodes, masksParent, maskFileName, maskName]);
+  }, [masksNodes, masksParent, maskFileName, maskName, maskColor]);
 
   // Update color when maskColor changes (mask name unchanged)
   useEffect(() => {

--- a/src/pages/Battle/Arena.tsx
+++ b/src/pages/Battle/Arena.tsx
@@ -6,7 +6,7 @@ import { hasActiveEffectFromSource } from '../../services/combatUtils';
 import { CombatantModel, CombatantModelHandle } from './CombatantModel';
 import { useEffect, useRef } from 'react';
 import { useThree } from '@react-three/fiber';
-import { useSettings } from '../../context/Settings';
+import { useSettings } from '../../context/useSettings';
 
 function EnvironmentIntensity({ value }: { value: number }) {
   const scene = useThree((s) => s.scene);

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -1,5 +1,5 @@
 import { resetGameData } from '../../services/gamePersistence';
-import { useSettings } from '../../context/Settings';
+import { useSettings } from '../../context/useSettings';
 import './index.scss';
 
 export default function SettingsPage() {


### PR DESCRIPTION
Fix various lint warnings and refactor `Settings` context to resolve `react-refresh` issues.

The `react-refresh` warning in `Settings.tsx` was due to it exporting both a React component and other non-component values (context, types, hooks). This PR refactors these exports into separate files (`SettingsContext.ts` and `useSettings.ts`) to comply with React Fast Refresh requirements.

---
<p><a href="https://cursor.com/agents/bc-7bad58ab-c781-4578-b850-50a97c4de127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bad58ab-c781-4578-b850-50a97c4de127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

