### PR TITLE
Cutscene background step

### DIFF
--- a/src/components/VisualNovelCutscene/index.scss
+++ b/src/components/VisualNovelCutscene/index.scss
@@ -81,6 +81,10 @@
       padding: 2rem;
       max-height: 100vh;
     }
+
+    &--background {
+      cursor: pointer;
+    }
   }
 
   &__speaker-side {

--- a/src/types/Cutscenes.ts
+++ b/src/types/Cutscenes.ts
@@ -38,8 +38,20 @@ export interface VideoStep {
   videoId: string;
 }
 
-/** A single step in a visual novel cutscene: dialogue or video */
-export type VisualNovelStep = DialogueStep | VideoStep | NarrationStep;
+/**
+ * A background-change step that swaps the cutscene backdrop.
+ * By default it auto-proceeds to the next step immediately.
+ * Set autoProceed to false to pause and wait for user input.
+ */
+export interface BackgroundStep {
+  type: 'background';
+  background: string | { type: 'gradient'; from: string; to: string };
+  /** When true (the default), advance to the next step immediately. */
+  autoProceed?: boolean;
+}
+
+/** A single step in a visual novel cutscene */
+export type VisualNovelStep = DialogueStep | VideoStep | NarrationStep | BackgroundStep;
 
 /**
  * Visual novel cutscene definition.
@@ -66,6 +78,10 @@ export function isDialogueStep(step: VisualNovelStep): step is DialogueStep {
 
 export function isVideoStep(step: VisualNovelStep): step is VideoStep {
   return step.type === 'video';
+}
+
+export function isBackgroundStep(step: VisualNovelStep): step is BackgroundStep {
+  return step.type === 'background';
 }
 
 /** Quest reward cutscene: reference to a visual novel cutscene by ID */


### PR DESCRIPTION
Add `BackgroundStep` to visual novel cutscenes to enable dynamic background changes with optional auto-proceed.

---
<p><a href="https://cursor.com/agents/bc-c82c7a5e-68d0-4658-ab56-ab7251033d66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c82c7a5e-68d0-4658-ab56-ab7251033d66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

