### PR TITLE
Reward calculation stability

### DIFF
--- a/src/pages/Battle/index.tsx
+++ b/src/pages/Battle/index.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { useGame } from '../../context/Game';
 import { BattlePhase } from '../../hooks/useBattleState';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useRef } from 'react';
 import { BattleInProgress } from './InProgress';
 import { BattlePrep } from './Prep';
 import { useSceneCanvas } from '../../hooks/useSceneCanvas';
@@ -18,16 +18,16 @@ export const BattlePage: React.FC = () => {
   const { currentEncounter, phase, currentWave, enemies, team } = battle;
   const { setScene } = useSceneCanvas();
 
-  const kranaRewards = useMemo(() => {
-    if (
-      !currentEncounter ||
-      (phase !== BattlePhase.Victory &&
-        phase !== BattlePhase.Defeat &&
-        phase !== BattlePhase.Retreated)
-    ) {
-      return [];
-    }
-    return computeKranaRewardsForBattle(
+  const kranaRewardsRef = useRef<ReturnType<typeof computeKranaRewardsForBattle> | null>(null);
+
+  const isOutcome =
+    currentEncounter &&
+    (phase === BattlePhase.Victory ||
+      phase === BattlePhase.Defeat ||
+      phase === BattlePhase.Retreated);
+
+  if (isOutcome && kranaRewardsRef.current === null) {
+    kranaRewardsRef.current = computeKranaRewardsForBattle(
       currentEncounter,
       phase,
       currentWave,
@@ -35,7 +35,13 @@ export const BattlePage: React.FC = () => {
       completedQuests,
       collectedKrana
     );
-  }, [currentEncounter, phase, currentWave, enemies, completedQuests, collectedKrana]);
+  }
+
+  if (!isOutcome) {
+    kranaRewardsRef.current = null;
+  }
+
+  const kranaRewards = kranaRewardsRef.current ?? [];
 
   useEffect(() => {
     if (!currentEncounter) {


### PR DESCRIPTION
Stabilize krana rewards by computing them once per battle outcome phase.

The previous `useMemo` for `kranaRewards` could re-execute due to dependency changes or React discarding memoized values, leading to `Math.random()` being called again and rewards changing on the outcome screen. This fix ensures rewards are calculated only once and stored in a `useRef`.

---
<p><a href="https://cursor.com/agents/bc-b9a67793-0e6c-44ce-a038-b370b064985e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9a67793-0e6c-44ce-a038-b370b064985e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

