### PR TITLE
fix: handle SKIP_WAITING message in custom service worker

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -138,7 +138,9 @@ self.addEventListener('message', (event) => {
   if (!event.data || !event.data.type) return;
   const { type } = event.data;
 
-  if (type === 'SCHEDULE_QUEST_NOTIFICATION') {
+  if (type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  } else if (type === 'SCHEDULE_QUEST_NOTIFICATION') {
     const { questId, questName, endsAtMs } = event.data as {
       questId: string;
       questName: string;


### PR DESCRIPTION
With injectManifest, the SKIP_WAITING handler that generateSW provided automatically is no longer present. Add it to the message listener so the PWABadge reload prompt works again.