### PR TITLE
Mask transition logic abstraction

### DIFF
--- a/src/hooks/maskTransition.ts
+++ b/src/hooks/maskTransition.ts
@@ -1,0 +1,137 @@
+import type { MutableRefObject } from 'react';
+import { Mesh, MeshPhysicalMaterial, MeshStandardMaterial, Object3D, Vector3 } from 'three';
+import { useFrame } from '@react-three/fiber';
+
+/** Duration of the mask swap transition in seconds */
+export const TRANSITION_DURATION = 0.35;
+
+/** How much the old mask scales up during the exit animation (multiplied on top of the original scale) */
+export const EXIT_SCALE_AMOUNT = 0.5;
+
+type StandardMat = MeshPhysicalMaterial | MeshStandardMaterial;
+
+function isStandardMat(mat: unknown): mat is StandardMat {
+  return mat instanceof MeshPhysicalMaterial || mat instanceof MeshStandardMaterial;
+}
+
+/** Cubic ease-out: fast start, gentle deceleration */
+export function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+/** Collect material uuid → its resting opacity for every mesh under an Object3D */
+export function collectOpacities(root: Object3D): Map<string, number> {
+  const map = new Map<string, number>();
+  root.traverse((child) => {
+    if ((child as Mesh).isMesh) {
+      const mat = (child as Mesh).material;
+      if (isStandardMat(mat)) {
+        map.set(mat.uuid, mat.opacity);
+      }
+    }
+  });
+  return map;
+}
+
+/**
+ * Set every standard material's opacity to `baseOpacity * factor`.
+ * Also disables depthWrite so the fading-out mask doesn't depth-clip
+ * the new mask that sits behind it in the same parent bone.
+ */
+export function setAnimatedOpacity(
+  root: Object3D,
+  opacities: Map<string, number>,
+  factor: number
+): void {
+  root.traverse((child) => {
+    if ((child as Mesh).isMesh) {
+      const mat = (child as Mesh).material;
+      if (isStandardMat(mat)) {
+        const base = opacities.get(mat.uuid) ?? 1;
+        mat.opacity = base * factor;
+        mat.depthWrite = false;
+      }
+    }
+  });
+}
+
+export interface MaskTransitionState {
+  active: boolean;
+  progress: number;
+  oldMask: Object3D | null;
+  /** Resting opacities of the OLD mask's materials (fade from these → 0) */
+  oldOpacities: Map<string, number>;
+  /** Original scale of the OLD mask before the exit animation began */
+  oldScale: Vector3;
+}
+
+export function createMaskTransitionState(): MaskTransitionState {
+  return {
+    active: false,
+    progress: 0,
+    oldMask: null,
+    oldOpacities: new Map(),
+    oldScale: new Vector3(1, 1, 1),
+  };
+}
+
+/**
+ * Starts a mask transition: captures the old mask's state and prepares it for
+ * the scale-up + fade-out animation. Call when the mask identity changes.
+ */
+export function startMaskTransition(
+  transitionRef: MutableRefObject<MaskTransitionState>,
+  masksParent: Object3D,
+  prevMask: Object3D
+): void {
+  const tr = transitionRef.current;
+  if (tr.active && tr.oldMask) {
+    masksParent.remove(tr.oldMask);
+  }
+
+  const oldOpacities = collectOpacities(prevMask);
+  const oldScale = prevMask.scale.clone();
+
+  transitionRef.current = {
+    active: true,
+    progress: 0,
+    oldMask: prevMask,
+    oldOpacities,
+    oldScale,
+  };
+}
+
+/**
+ * Hook that runs the per-frame mask transition animation. Call from any hook
+ * that manages mask swapping and uses MaskTransitionState.
+ */
+export function useMaskTransitionFrame(
+  transitionRef: MutableRefObject<MaskTransitionState>,
+  masksParentRef: MutableRefObject<Object3D | undefined>
+): void {
+  useFrame((_, delta) => {
+    const tr = transitionRef.current;
+    if (!tr.active) return;
+
+    tr.progress = Math.min(1, tr.progress + delta / TRANSITION_DURATION);
+    const t = easeOutCubic(tr.progress);
+
+    // Old mask: scale up relative to its original scale and fade out
+    if (tr.oldMask) {
+      const factor = 1 + t * EXIT_SCALE_AMOUNT;
+      tr.oldMask.scale.set(tr.oldScale.x * factor, tr.oldScale.y * factor, tr.oldScale.z * factor);
+      setAnimatedOpacity(tr.oldMask, tr.oldOpacities, 1 - t);
+    }
+
+    // Finished — remove the old mask from the scene
+    if (tr.progress >= 1) {
+      const parent = masksParentRef.current;
+      if (parent && tr.oldMask) {
+        parent.remove(tr.oldMask);
+      }
+
+      tr.active = false;
+      tr.oldMask = null;
+    }
+  });
+}

--- a/src/hooks/useMask.ts
+++ b/src/hooks/useMask.ts
@@ -1,18 +1,16 @@
 import { useEffect, useMemo, useRef } from 'react';
-import { Color, Mesh, MeshPhysicalMaterial, MeshStandardMaterial, Object3D, Vector3 } from 'three';
+import { Color, Mesh, MeshPhysicalMaterial, MeshStandardMaterial, Object3D } from 'three';
 import { useGLTF } from '@react-three/drei';
-import { useFrame } from '@react-three/fiber';
 import { useGame } from '../context/Game';
 import { getEffectiveMataMaskColor } from '../game/maskColor';
 import { BaseMatoran, MatoranStage } from '../types/Matoran';
+import {
+  createMaskTransitionState,
+  startMaskTransition,
+  useMaskTransitionFrame,
+} from './maskTransition';
 
 const MASKS_GLB_PATH = import.meta.env.BASE_URL + 'masks.glb';
-
-/** Duration of the mask swap transition in seconds */
-const TRANSITION_DURATION = 0.35;
-
-/** How much the old mask scales up during the exit animation (multiplied on top of the original scale) */
-const EXIT_SCALE_AMOUNT = 0.5;
 
 function buildMaskNodes(gltf: { scene: Object3D }): Record<string, Object3D> {
   const nodes: Record<string, Object3D> = {};
@@ -26,43 +24,6 @@ type StandardMat = MeshPhysicalMaterial | MeshStandardMaterial;
 
 function isStandardMat(mat: unknown): mat is StandardMat {
   return mat instanceof MeshPhysicalMaterial || mat instanceof MeshStandardMaterial;
-}
-
-/** Cubic ease-out: fast start, gentle deceleration */
-function easeOutCubic(t: number): number {
-  return 1 - Math.pow(1 - t, 3);
-}
-
-/** Collect material uuid → its resting opacity for every mesh under an Object3D */
-function collectOpacities(root: Object3D): Map<string, number> {
-  const map = new Map<string, number>();
-  root.traverse((child) => {
-    if ((child as Mesh).isMesh) {
-      const mat = (child as Mesh).material;
-      if (isStandardMat(mat)) {
-        map.set(mat.uuid, mat.opacity);
-      }
-    }
-  });
-  return map;
-}
-
-/**
- * Set every standard material's opacity to `baseOpacity * factor`.
- * Also disables depthWrite so the fading-out mask doesn't depth-clip
- * the new mask that sits behind it in the same parent bone.
- */
-function setAnimatedOpacity(root: Object3D, opacities: Map<string, number>, factor: number): void {
-  root.traverse((child) => {
-    if ((child as Mesh).isMesh) {
-      const mat = (child as Mesh).material;
-      if (isStandardMat(mat)) {
-        const base = opacities.get(mat.uuid) ?? 1;
-        mat.opacity = base * factor;
-        mat.depthWrite = false;
-      }
-    }
-  });
 }
 
 /** Apply mask color and optional glow color to every mesh material under `root` */
@@ -85,16 +46,6 @@ function applyMaskColors(root: Object3D, maskColor: string, glowColor?: string):
       }
     }
   });
-}
-
-interface TransitionState {
-  active: boolean;
-  progress: number;
-  oldMask: Object3D | null;
-  /** Resting opacities of the OLD mask's materials (fade from these → 0) */
-  oldOpacities: Map<string, number>;
-  /** Original scale of the OLD mask before the exit animation began */
-  oldScale: Vector3;
 }
 
 /**
@@ -146,13 +97,7 @@ export function useMask(
   const glowColorRef = useRef(glowColor);
   glowColorRef.current = glowColor;
 
-  const transitionRef = useRef<TransitionState>({
-    active: false,
-    progress: 0,
-    oldMask: null,
-    oldOpacities: new Map(),
-    oldScale: new Vector3(1, 1, 1),
-  });
+  const transitionRef = useRef(createMaskTransitionState());
 
   // Clone the mask and attach to parent; animate transitions between masks
   useEffect(() => {
@@ -195,22 +140,7 @@ export function useMask(
       prevMaskNameRef.current !== null && prevMaskNameRef.current !== maskName && prevMask !== null;
 
     if (isChange && prevMask) {
-      // Cancel any already-running transition and clean up its old mask
-      const tr = transitionRef.current;
-      if (tr.active && tr.oldMask) {
-        masksParent.remove(tr.oldMask);
-      }
-
-      const oldOpacities = collectOpacities(prevMask);
-      const oldScale = prevMask.scale.clone();
-
-      transitionRef.current = {
-        active: true,
-        progress: 0,
-        oldMask: prevMask,
-        oldOpacities,
-        oldScale,
-      };
+      startMaskTransition(transitionRef, masksParent, prevMask);
     } else if (prevMask) {
       // Not a mask-name change (e.g. masksNodes just loaded); swap silently
       masksParent.remove(prevMask);
@@ -240,32 +170,7 @@ export function useMask(
     };
   }, []);
 
-  // Per-frame transition animation
-  useFrame((_, delta) => {
-    const tr = transitionRef.current;
-    if (!tr.active) return;
-
-    tr.progress = Math.min(1, tr.progress + delta / TRANSITION_DURATION);
-    const t = easeOutCubic(tr.progress);
-
-    // Old mask: scale up relative to its original scale and fade out
-    if (tr.oldMask) {
-      const factor = 1 + t * EXIT_SCALE_AMOUNT;
-      tr.oldMask.scale.set(tr.oldScale.x * factor, tr.oldScale.y * factor, tr.oldScale.z * factor);
-      setAnimatedOpacity(tr.oldMask, tr.oldOpacities, 1 - t);
-    }
-
-    // Finished — remove the old mask from the scene
-    if (tr.progress >= 1) {
-      const parent = masksParentRef.current;
-      if (parent && tr.oldMask) {
-        parent.remove(tr.oldMask);
-      }
-
-      tr.active = false;
-      tr.oldMask = null;
-    }
-  });
+  useMaskTransitionFrame(transitionRef, masksParentRef);
 
   // Apply color when only the color props change (maskName unchanged)
   useEffect(() => {

--- a/src/hooks/useNuvaMask.ts
+++ b/src/hooks/useNuvaMask.ts
@@ -4,6 +4,11 @@ import { useGLTF } from '@react-three/drei';
 import { BaseMatoran, Mask, RecruitedCharacterData } from '../types/Matoran';
 import { useGame } from '../context/Game';
 import { getEffectiveNuvaMaskColor } from '../game/maskColor';
+import {
+  createMaskTransitionState,
+  startMaskTransition,
+  useMaskTransitionFrame,
+} from './maskTransition';
 
 const NUVA_MASKS_GLB_PATH = import.meta.env.BASE_URL + 'Toa_Nuva/masks.glb';
 
@@ -76,6 +81,16 @@ export function useNuvaMask(
   const gltf = useGLTF(NUVA_MASKS_GLB_PATH); // useDraco=true by default for Draco-compressed GLB
   const masksNodes = useMemo(() => buildNuvaMaskNodes(gltf), [gltf]);
   const maskRef = useRef<Object3D | null>(null);
+  const prevMaskFileNameRef = useRef<string | null>(null);
+  const masksParentRef = useRef<Object3D | undefined>(masksParent);
+  masksParentRef.current = masksParent;
+
+  const maskColorRef = useRef(maskColor);
+  maskColorRef.current = maskColor;
+  const maskNameRef = useRef(maskName);
+  maskNameRef.current = maskName;
+
+  const transitionRef = useRef(createMaskTransitionState());
 
   useEffect(() => {
     if (!masksNodes || !masksParent) return;
@@ -102,21 +117,40 @@ export function useNuvaMask(
       }
     });
 
-    applyNuvaMaskColors(clone, maskColor, maskName);
+    applyNuvaMaskColors(clone, maskColorRef.current, maskNameRef.current);
 
-    if (maskRef.current) {
-      masksParent.remove(maskRef.current);
+    const prevMask = maskRef.current;
+    const isChange =
+      prevMaskFileNameRef.current !== null &&
+      prevMaskFileNameRef.current !== maskFileName &&
+      prevMask !== null;
+
+    if (isChange && prevMask) {
+      startMaskTransition(transitionRef, masksParent, prevMask);
+    } else if (prevMask) {
+      masksParent.remove(prevMask);
     }
+
     masksParent.add(clone);
     maskRef.current = clone;
+    prevMaskFileNameRef.current = maskFileName;
+  }, [masksNodes, masksParent, maskFileName]);
 
+  useEffect(() => {
     return () => {
-      masksParent.remove(clone);
+      const parent = masksParentRef.current;
+      if (parent) {
+        if (maskRef.current) parent.remove(maskRef.current);
+        const tr = transitionRef.current;
+        if (tr.active && tr.oldMask) parent.remove(tr.oldMask);
+      }
       maskRef.current = null;
+      transitionRef.current.active = false;
     };
-  }, [masksNodes, masksParent, maskFileName, maskName, maskColor]);
+  }, []);
 
-  // Update color when maskColor changes (mask name unchanged)
+  useMaskTransitionFrame(transitionRef, masksParentRef);
+
   useEffect(() => {
     const mask = maskRef.current;
     if (!mask) return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Abstract mask transition logic into a shared module and apply it to `useMask` and `useNuvaMask`.

This change ensures `useNuvaMask` now has the same smooth transition effect as `useMask` when the mask changes, by centralizing the animation logic and reusing it across both hooks.

---
<p><a href="https://cursor.com/agents/bc-4646d4e9-afe6-4769-bbc2-36ae6e1eff53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4646d4e9-afe6-4769-bbc2-36ae6e1eff53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->