### PR TITLE
Service worker reload failure

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,13 +1,20 @@
 /// <reference lib="webworker" />
 
 import { clientsClaim } from 'workbox-core';
-import { precacheAndRoute, cleanupOutdatedCaches } from 'workbox-precaching';
+import { precacheAndRoute, cleanupOutdatedCaches, createHandlerBoundToURL } from 'workbox-precaching';
+import { registerRoute, NavigationRoute } from 'workbox-routing';
 
 declare let self: ServiceWorkerGlobalScope;
+
+const BASE = import.meta.env.BASE_URL;
 
 clientsClaim();
 cleanupOutdatedCaches();
 precacheAndRoute(self.__WB_MANIFEST);
+
+// Navigation fallback: serve index.html for SPA routes (e.g. /battle/selector).
+// Without this, reloading on non-homepage routes hits GitHub Pages directly and returns 404.
+registerRoute(new NavigationRoute(createHandlerBoundToURL(`${BASE}index.html`)));
 
 // ---------------------------------------------------------------------------
 // IndexedDB helpers for persisting notification schedules across SW restarts


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a navigation fallback to the service worker to fix 404 errors when reloading on non-homepage SPA routes.

Previously, when reloading on a non-homepage SPA route (e.g., `/battle/selector`) after a service worker update, the browser would request the URL directly from GitHub Pages, which would return a 404 because no physical file exists at that path. The service worker was not configured to handle these navigation requests. This change registers a `NavigationRoute` to serve `index.html` for all navigation requests that don't match a precached asset, allowing the client-side application to handle routing.

---
<p><a href="https://cursor.com/agents/bc-987fdd31-8e86-493e-bec9-97a6578a6345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-987fdd31-8e86-493e-bec9-97a6578a6345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->