### PR TITLE
No scene canvas content

### DIFF
--- a/src/context/Canvas.tsx
+++ b/src/context/Canvas.tsx
@@ -1,18 +1,18 @@
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { Canvas, useThree } from '@react-three/fiber';
 import { useLocation } from 'react-router-dom';
 import { PCFSoftShadowMap, SRGBColorSpace } from 'three';
 import { SceneCanvasContext } from '../hooks/useSceneCanvas';
 import { Perf } from 'r3f-perf';
 import { useSettings } from './useSettings';
 
-/** Clears the WebGL buffer every frame when there is no scene. Prevents stale content from showing if the canvas is revealed. */
+/** Clears the WebGL buffer when there is no scene. Prevents stale content from showing if the canvas is revealed. */
 function ClearCanvas() {
   const gl = useThree((s) => s.gl);
-  useFrame(() => {
+  useEffect(() => {
     gl.clear(true, true, true);
-  });
+  }, [gl]);
   return null;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Clear the WebGL canvas when no scene is present to prevent stale content from being displayed.

When navigating to routes without a scene, the canvas was only hidden with `display: none`, leaving the last rendered frame in the WebGL buffer. This change introduces a `ClearCanvas` component that actively clears the buffer when `scene` is `null`, ensuring a blank canvas.

---
<p><a href="https://cursor.com/agents/bc-0f986b3f-b85b-41c5-9148-128c8972f748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f986b3f-b85b-41c5-9148-128c8972f748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->