### PR TITLE
Start completed quest sections collapsed

### DIFF
--- a/e2e/cutscene.spec.ts
+++ b/e2e/cutscene.spec.ts
@@ -10,6 +10,7 @@ async function openDialogueCutscene(page: import('@playwright/test').Page) {
   await setupGameState(page, COMPLETED_QUEST_WITH_CUTSCENE);
   await goto(page, '/quests', { hideCanvasBeforeNav: true });
   await page.locator('h2.quests-page__title').first().waitFor({ state: 'visible', timeout: 10000 });
+  await page.locator('.quests-page__section-title:has-text("The Cronicler\'s Journey")').click();
   await page.locator('.quests-page__item-title:has-text("A call for help")').click();
   await page.locator('button:has-text("Replay Cutscene")').click();
   await page

--- a/e2e/cutscene.spec.ts
+++ b/e2e/cutscene.spec.ts
@@ -25,6 +25,7 @@ async function openVideoCutscene(page: import('@playwright/test').Page) {
   });
   await goto(page, '/quests', { hideCanvasBeforeNav: true });
   await page.locator('h2.quests-page__title').first().waitFor({ state: 'visible', timeout: 10000 });
+  await page.locator('.quests-page__section-title:has-text("Arrival of the Toa")').click();
   await page.locator('.quests-page__item-title:has-text("The Arrival of the Toa")').click();
   await page.locator('button:has-text("Replay Cutscene")').click();
   await page

--- a/src/pages/Quests/index.tsx
+++ b/src/pages/Quests/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Bell, BellOff, ChevronDown, ChevronRight } from 'lucide-react';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { AvailableQuests } from '../../components/AvailableQuests';
@@ -141,18 +141,6 @@ export const QuestsPage = () => {
       );
   }, [completedQuests]);
 
-  useEffect(() => {
-    if (!completedSections.length) return;
-    setExpandedSections((prev) => {
-      if (Object.keys(prev).length) return prev;
-      const initial: Record<string, boolean> = {};
-      completedSections.forEach((s) => {
-        initial[s.section] = true;
-      });
-      return initial;
-    });
-  }, [completedSections]);
-
   const handleCutscene = (ref: VisualNovelCutsceneRef) => {
     setActiveCutscene(ref);
   };
@@ -236,7 +224,7 @@ export const QuestsPage = () => {
       ) : (
         <div className="quests-page__sections">
           {completedSections.map((sec) => {
-            const isSectionExpanded = expandedSections[sec.section] ?? true;
+            const isSectionExpanded = expandedSections[sec.section] ?? false;
             return (
               <div key={sec.section} className="quests-page__section">
                 <button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the Quests page, **Completed Quests** section groups (by quest `section`) now load **collapsed** instead of expanded.

## Changes

- Removed the `useEffect` that initialized every section to expanded on first render.
- Default `expandedSections[section]` to `false` when unset (was `true`), so new sections also start collapsed.

## Testing

- `yarn lint`
- `yarn test:ci`

**Note:** E2E visual snapshots for `/quests` may need updating if they assumed expanded completed sections.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1110ec4e-6705-4dd4-9d80-47fd23756460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1110ec4e-6705-4dd4-9d80-47fd23756460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

