### PR TITLE
feat: finish Phase 0 - battle outcome review & mask activation effects

### DIFF
--- a/docs/UI_UX_STRATEGY.md
+++ b/docs/UI_UX_STRATEGY.md
@@ -340,7 +340,7 @@ These changes are self-contained, low-risk, and immediately improve feel:
 
 4. **Wave transition** — ✅ On wave clear, brief 400ms CSS fade-to-black-and-back on `.battle-arena` before next wave spawns.
 
-5. **Outcome screen polish** — Animate reward items appearing one by one (staggered `motion.div` with spring physics). Show exp gain as an animated bar fill.
+5. **Outcome screen polish** ✅ — Animate reward items appearing one by one (staggered `motion.div` with spring physics). Show exp gain as an animated bar fill.
 
 ### First 3D expansion (Phase 1)
 

--- a/docs/UI_UX_STRATEGY.md
+++ b/docs/UI_UX_STRATEGY.md
@@ -138,11 +138,11 @@ Keep the current flat UI, invest in motion design, illustration, and polish. Bet
 - [x] Replace `alert()` in recruitment with an animated modal + 3D reveal
 - [x] Move battle action buttons ("Run Round", "Retreat") into a fixed bottom bar within thumb reach
 - [x] Add screen shake (CSS transform on `.main-content`) on critical hits
-- [ ] Add elemental particle burst on mask power activation (CSS or canvas 2D overlay)
+- [x] Add elemental particle burst on mask power activation (CSS or canvas 2D overlay)
 - [x] Improve damage popup with size scaling by damage magnitude, crit styling
 - [x] Add a brief "wave transition" animation between waves (fade or wipe)
 - [x] Add haptic feedback (`navigator.vibrate`) on hits and rewards
-- [ ] Style the battle outcome screen — animated loot cards, exp bar fill
+- [x] Style the battle outcome screen — animated loot cards, exp bar fill
 
 ### Phase 1: Persistent Canvas & Battle Enhancement
 

--- a/src/game/BattleRewards.spec.ts
+++ b/src/game/BattleRewards.spec.ts
@@ -3,6 +3,7 @@ import { ElementTribe } from '../types/Matoran';
 import { BattleStrategy, type Combatant, type EnemyEncounter } from '../types/Combat';
 import type { KranaCollection } from '../types/Krana';
 import {
+  computeBattleExpPerParticipant,
   computeBattleExpTotal,
   computeKranaRewardsForBattle,
   getDefeatedEnemyElements,
@@ -116,6 +117,28 @@ describe('BattleRewards', () => {
       ];
       const total = computeBattleExpTotal(encounter, BattlePhase.Defeat, 1, currentEnemies);
       expect(total).toBe(20 * 5 + 25 * 5);
+    });
+  });
+
+  describe('computeBattleExpPerParticipant', () => {
+    test('matches floor(total / unique participant count)', () => {
+      const team = [
+        baseCombatant({ id: 'Toa_Tahu' }),
+        baseCombatant({ id: 'Toa_Gali' }),
+        baseCombatant({ id: 'Toa_Onua' }),
+      ];
+      expect(computeBattleExpPerParticipant(team, 100)).toBe(33);
+      expect(computeBattleExpPerParticipant(team, 0)).toBe(0);
+      expect(computeBattleExpPerParticipant([], 50)).toBe(0);
+    });
+
+    test('uses unique ids only when splitting', () => {
+      const team = [
+        baseCombatant({ id: 'Toa_Tahu' }),
+        baseCombatant({ id: 'Toa_Gali' }),
+        baseCombatant({ id: 'Toa_Tahu' }),
+      ];
+      expect(computeBattleExpPerParticipant(team, 10)).toBe(5);
     });
   });
 

--- a/src/game/BattleRewards.ts
+++ b/src/game/BattleRewards.ts
@@ -81,6 +81,15 @@ export function getParticipantIds(team: Combatant[]): string[] {
 }
 
 /**
+ * EXP each unique participant receives when rewards are applied (`floor(total / unique ids)`).
+ */
+export function computeBattleExpPerParticipant(team: Combatant[], expTotal: number): number {
+  const n = getParticipantIds(team).length;
+  if (n === 0 || expTotal <= 0) return 0;
+  return Math.floor(expTotal / n);
+}
+
+/**
  * Element of each defeated enemy (one per enemy), in order, for Krana rolls.
  * Uses Bohrok element from COMBATANT_DEX for wave slots; current wave uses combatant.element.
  */

--- a/src/game/Krana.ts
+++ b/src/game/Krana.ts
@@ -77,6 +77,16 @@ export const ELEMENT_TO_KRANA_COLOR: Record<KranaElement, string> = {
   [ElementTribe.Stone]: 'green',
 };
 
+/** Hex color per Krana element, used for UI tinting (e.g. Battle outcome screen). */
+export const ELEMENT_TO_KRANA_COLOR_HEX: Record<KranaElement, string> = {
+  [ElementTribe.Fire]: '#036be3',
+  [ElementTribe.Water]: '#ff7300',
+  [ElementTribe.Air]: '#d60202',
+  [ElementTribe.Earth]: '#84ff00',
+  [ElementTribe.Ice]: '#00e1ff',
+  [ElementTribe.Stone]: '#006e06',
+};
+
 function isKranaDropId(id: string): boolean {
   return id.startsWith('krana-');
 }

--- a/src/hooks/useGameLogic.tsx
+++ b/src/hooks/useGameLogic.tsx
@@ -14,6 +14,7 @@ import { KranaCollection, KranaElement, KranaId } from '../types/Krana';
 import { BattleRewardParams, KranaReward } from '../types/GameState';
 import { RecruitedCharacterData } from '../types/Matoran';
 import {
+  computeBattleExpPerParticipant,
   computeBattleExpTotal,
   computeKranaRewardsForBattle,
   computeKraataRewardsForBattle,
@@ -306,7 +307,7 @@ export const useGameLogic = (): GameState & GameStateEditorApi => {
       );
       const participantIds = getParticipantIds(params.team);
       if (participantIds.length > 0 && totalExp > 0) {
-        const expPerParticipant = Math.floor(totalExp / participantIds.length);
+        const expPerParticipant = computeBattleExpPerParticipant(params.team, totalExp);
         setRecruitedCharacters((prev) =>
           prev.map((m) =>
             participantIds.includes(m.id) ? { ...m, exp: m.exp + expPerParticipant } : m

--- a/src/pages/Battle/BattleOutcome.scss
+++ b/src/pages/Battle/BattleOutcome.scss
@@ -36,6 +36,9 @@
   gap: 0.75rem;
   position: fixed;
   bottom: 180px;
+  max-height: calc(100vh - 10.5rem);
+  min-height: 0;
+  overflow: hidden;
 }
 
 .battle-outcome__stats {
@@ -84,26 +87,66 @@
   color: var(--color-accent);
 }
 
-.battle-outcome__exp-per-toa {
-  font-weight: 400;
-  font-size: 0.85rem;
-  color: var(--color-text-secondary);
+.battle-outcome__exp-team {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.4rem;
+  margin-top: 0.35rem;
 }
 
-.battle-outcome__exp-track {
-  height: 0.5rem;
-  border-radius: 0.25rem;
+.battle-outcome__exp-toa-card.character-card {
+  cursor: default;
+  padding: 0.35rem 0.35rem 0.45rem;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.battle-outcome__exp-toa-avatar.model-preview {
+  max-height: 4.25rem;
+  margin-top: 0;
+}
+
+.battle-outcome__exp-toa-header.card-header {
+  font-size: 0.65rem;
+  margin-bottom: 0.15rem;
+  line-height: 1.05;
+
+  .level-label {
+    font-size: 0.55rem;
+    margin: 0.08rem 0 0;
+  }
+}
+
+.battle-outcome__exp-toa-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.22rem;
+  align-items: stretch;
+  width: 100%;
+}
+
+.battle-outcome__exp-toa-amount {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--color-accent);
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.battle-outcome__exp-toa-track {
+  height: 0.35rem;
+  border-radius: 0.2rem;
   background: #151515;
   border: 1px solid #3a3a3a;
   overflow: hidden;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.45);
 }
 
-.battle-outcome__exp-fill {
+.battle-outcome__exp-toa-fill {
   height: 100%;
   border-radius: inherit;
   background: linear-gradient(90deg, var(--color-accent) 0%, #ffe566 100%);
-  box-shadow: 0 0 8px rgba(252, 239, 110, 0.45);
+  box-shadow: 0 0 6px rgba(252, 239, 110, 0.4);
 }
 
 // Loot section
@@ -111,6 +154,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .battle-outcome__loot-heading {
@@ -120,39 +165,72 @@
   color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
+  flex-shrink: 0;
+}
+
+.battle-outcome__loot-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: clamp(10rem, 42vh, 22rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  padding-right: 0.25rem;
+  margin-right: -0.25rem;
 }
 
 .battle-outcome__loot-grid {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(7.25rem, 1fr));
   gap: 0.5rem;
+  align-content: start;
 }
 
 .battle-outcome__loot-card {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.4rem 0.75rem;
+  gap: 0.2rem;
+  padding: 0.35rem 0.55rem;
   border-radius: var(--border-radius-sm);
   background: var(--color-surface-elevated);
   border: 1px solid var(--color-border-subtle);
   box-shadow: var(--shadow-sm);
+  min-width: 0;
 
   &--kraata {
     border-color: #555;
+    align-items: flex-start;
   }
 }
 
-.battle-outcome__loot-img {
-  width: 2rem;
-  height: 2rem;
-  object-fit: contain;
-  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.2));
+/* Loot chips are too small for collection-style multiply (reads as a flat paint bucket).
+   `color` blend keeps backdrop luminance (mask shading) and applies the krana hue instead. */
+.battle-outcome__loot-krana-img-wrap {
+  flex-shrink: 0;
+  width: 2.25rem;
+  height: 2.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
 }
 
-.battle-outcome__loot-icon {
-  font-size: 1.25rem;
-  line-height: 1;
+.battle-outcome__loot-img {
+  position: relative;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: drop-shadow(0 0 3px rgba(255, 255, 255, 0.15));
+}
+
+.battle-outcome__loot-kraata {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  display: block;
+  object-fit: contain;
+  filter: drop-shadow(0 0 3px rgba(255, 255, 255, 0.15));
 }
 
 .battle-outcome__loot-label {
@@ -161,6 +239,26 @@
   font-size: 0.85rem;
   font-weight: 500;
   line-height: 1.2;
+  min-width: 0;
+}
+
+.battle-outcome__loot-kraata-title {
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.battle-outcome__loot-kraata-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  margin-top: 0.1rem;
+}
+
+.battle-outcome__loot-kraata-stage {
+  font-size: 0.95rem;
+  line-height: 1;
+  color: var(--color-text-muted);
 }
 
 .battle-outcome__loot-element {
@@ -170,10 +268,9 @@
 }
 
 .battle-outcome__loot-qty {
-  font-size: 0.75rem;
-  font-weight: 400;
-  color: var(--color-text-secondary);
-  margin-left: 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--color-accent);
 }
 
 .battle-outcome__no-loot {

--- a/src/pages/Battle/BattleOutcome.scss
+++ b/src/pages/Battle/BattleOutcome.scss
@@ -1,0 +1,194 @@
+.battle-outcome__title {
+  font-size: clamp(2rem, 8vw, 3.5rem);
+  font-family: var(--font-display);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-align: center;
+  margin: 0 0 0.75rem;
+
+  &--victory {
+    color: var(--color-accent);
+    text-shadow:
+      0 0 20px rgba(252, 239, 110, 0.5),
+      0 0 40px rgba(252, 239, 110, 0.25);
+  }
+
+  &--defeat {
+    color: #f87171;
+    text-shadow: 0 0 20px rgba(248, 113, 113, 0.4);
+  }
+
+  &--retreat {
+    color: var(--color-text-muted);
+  }
+}
+
+.battle-outcome__panel {
+  width: 100%;
+  max-width: 420px;
+  padding: 1.25rem 1.5rem;
+  background-color: var(--color-surface-high);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-lg), var(--shadow-glow);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  position: fixed;
+  bottom: 180px;
+}
+
+.battle-outcome__stats {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.battle-outcome__stat-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.battle-outcome__stat-label {
+  color: var(--color-text-muted);
+}
+
+.battle-outcome__stat-value {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+// EXP section
+.battle-outcome__exp-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.battle-outcome__exp-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.battle-outcome__exp-label {
+  color: var(--color-text-muted);
+}
+
+.battle-outcome__exp-value {
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.battle-outcome__exp-per-toa {
+  font-weight: 400;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.battle-outcome__exp-track {
+  height: 0.5rem;
+  border-radius: 0.25rem;
+  background: #151515;
+  border: 1px solid #3a3a3a;
+  overflow: hidden;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.45);
+}
+
+.battle-outcome__exp-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--color-accent) 0%, #ffe566 100%);
+  box-shadow: 0 0 8px rgba(252, 239, 110, 0.45);
+}
+
+// Loot section
+.battle-outcome__loot-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.battle-outcome__loot-heading {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.battle-outcome__loot-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.battle-outcome__loot-card {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: var(--border-radius-sm);
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border-subtle);
+  box-shadow: var(--shadow-sm);
+
+  &--kraata {
+    border-color: #555;
+  }
+}
+
+.battle-outcome__loot-img {
+  width: 2rem;
+  height: 2rem;
+  object-fit: contain;
+  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.2));
+}
+
+.battle-outcome__loot-icon {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.battle-outcome__loot-label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.battle-outcome__loot-element {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--color-text-secondary);
+}
+
+.battle-outcome__loot-qty {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--color-text-secondary);
+  margin-left: 0.25rem;
+}
+
+.battle-outcome__no-loot {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  font-style: italic;
+  text-align: center;
+}
+
+.battle-outcome__empty {
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.battle-outcome__collect {
+  margin-top: 0.25rem;
+}

--- a/src/pages/Battle/BattleOutcome.tsx
+++ b/src/pages/Battle/BattleOutcome.tsx
@@ -1,0 +1,283 @@
+import { motion, useReducedMotion } from 'motion/react';
+import { useMemo } from 'react';
+import { BattlePhase } from '../../hooks/useBattleState';
+import { KRAATA_POWER_NAMES, KraataReward } from '../../types/Kraata';
+import { KranaReward } from '../../types/GameState';
+import { ELEMENT_TO_KRANA_COLOR } from '../../game/Krana';
+import { buildTransition, MOTION_DURATION, MOTION_EASING } from '../../motion/transitions';
+import { isTestMode } from '../../utils/testMode';
+
+import './BattleOutcome.scss';
+
+interface BattleOutcomeProps {
+  phase: BattlePhase;
+  enemiesDefeated: number;
+  expTotal: number;
+  participantCount: number;
+  kranaRewards: KranaReward[];
+  kraataRewards: KraataReward[];
+  onCollect: () => void;
+}
+
+function OutcomeTitle({ phase }: { phase: BattlePhase }) {
+  const label =
+    phase === BattlePhase.Victory
+      ? 'Victory!'
+      : phase === BattlePhase.Defeat
+        ? 'Defeat'
+        : 'Retreated';
+
+  const className =
+    phase === BattlePhase.Victory
+      ? 'battle-outcome__title battle-outcome__title--victory'
+      : phase === BattlePhase.Defeat
+        ? 'battle-outcome__title battle-outcome__title--defeat'
+        : 'battle-outcome__title battle-outcome__title--retreat';
+
+  return <h1 className={className}>{label}</h1>;
+}
+
+function ExpBar({
+  expTotal,
+  participantCount,
+  reduceMotion,
+}: {
+  expTotal: number;
+  participantCount: number;
+  reduceMotion: boolean;
+}) {
+  const perToa = participantCount > 0 ? Math.floor(expTotal / participantCount) : 0;
+  const transition = buildTransition(
+    { duration: MOTION_DURATION.verySlow, ease: MOTION_EASING.standard },
+    reduceMotion
+  );
+
+  return (
+    <div className="battle-outcome__exp-section">
+      <div className="battle-outcome__exp-header">
+        <span className="battle-outcome__exp-label">EXP earned</span>
+        <span className="battle-outcome__exp-value">
+          {expTotal > 0 ? (
+            <>
+              +{expTotal}{' '}
+              {participantCount > 0 && (
+                <span className="battle-outcome__exp-per-toa">({perToa} per Toa)</span>
+              )}
+            </>
+          ) : (
+            <span className="battle-outcome__empty">0</span>
+          )}
+        </span>
+      </div>
+      {expTotal > 0 && (
+        <div className="battle-outcome__exp-track">
+          <motion.div
+            className="battle-outcome__exp-fill"
+            initial={{ width: '0%' }}
+            animate={{ width: '100%' }}
+            transition={transition}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function KranaRewardCard({
+  reward,
+  index,
+  reduceMotion,
+}: {
+  reward: KranaReward;
+  index: number;
+  reduceMotion: boolean;
+}) {
+  const color = ELEMENT_TO_KRANA_COLOR[reward.element];
+  const transition = buildTransition(
+    {
+      duration: MOTION_DURATION.slow,
+      ease: MOTION_EASING.emphasized,
+      delay: 0.3 + index * 0.12,
+    },
+    reduceMotion
+  );
+
+  return (
+    <motion.div
+      className={`battle-outcome__loot-card krana-color--${color}`}
+      initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 20, scale: 0.85 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      transition={transition}
+    >
+      <img
+        src={`${import.meta.env.BASE_URL}/avatar/Krana/${reward.kranaId}.webp`}
+        alt={`Krana ${reward.kranaId}`}
+        className="battle-outcome__loot-img"
+      />
+      <span className="battle-outcome__loot-label">
+        Krana {reward.kranaId}
+        <span className="battle-outcome__loot-element">{reward.element}</span>
+      </span>
+    </motion.div>
+  );
+}
+
+function KraataRewardCard({
+  reward,
+  index,
+  startOffset,
+  reduceMotion,
+}: {
+  reward: KraataReward;
+  index: number;
+  startOffset: number;
+  reduceMotion: boolean;
+}) {
+  const label = KRAATA_POWER_NAMES[reward.power] ?? reward.power;
+  const transition = buildTransition(
+    {
+      duration: MOTION_DURATION.slow,
+      ease: MOTION_EASING.emphasized,
+      delay: 0.3 + (startOffset + index) * 0.12,
+    },
+    reduceMotion
+  );
+
+  return (
+    <motion.div
+      className="battle-outcome__loot-card battle-outcome__loot-card--kraata"
+      initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 20, scale: 0.85 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      transition={transition}
+    >
+      <span className="battle-outcome__loot-icon">🐛</span>
+      <span className="battle-outcome__loot-label">
+        Kraata of {label}
+        {reward.qty > 1 && <span className="battle-outcome__loot-qty">x{reward.qty}</span>}
+      </span>
+    </motion.div>
+  );
+}
+
+export function BattleOutcome({
+  phase,
+  enemiesDefeated,
+  expTotal,
+  participantCount,
+  kranaRewards,
+  kraataRewards,
+  onCollect,
+}: BattleOutcomeProps) {
+  const shouldReduceMotion = (useReducedMotion() ?? false) || isTestMode();
+
+  const hasLoot = kranaRewards.length > 0 || kraataRewards.length > 0;
+  const lootDelay = 0.3 + (kranaRewards.length + kraataRewards.length) * 0.12;
+
+  const panelTransition = useMemo(
+    () =>
+      buildTransition(
+        { duration: MOTION_DURATION.slow, ease: MOTION_EASING.standard },
+        shouldReduceMotion
+      ),
+    [shouldReduceMotion]
+  );
+
+  const collectTransition = useMemo(
+    () =>
+      buildTransition(
+        {
+          duration: MOTION_DURATION.base,
+          ease: MOTION_EASING.standard,
+          delay: hasLoot ? lootDelay + 0.15 : 0.6,
+        },
+        shouldReduceMotion
+      ),
+    [shouldReduceMotion, hasLoot, lootDelay]
+  );
+
+  return (
+    <>
+      <motion.div
+        initial={shouldReduceMotion ? undefined : { opacity: 0, scale: 0.8 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={panelTransition}
+      >
+        <OutcomeTitle phase={phase} />
+      </motion.div>
+
+      <div className="battle-arena"></div>
+
+      <div className="battle-outcome__panel">
+        <motion.div
+          className="battle-outcome__stats"
+          initial={shouldReduceMotion ? undefined : { opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={buildTransition(
+            { duration: MOTION_DURATION.base, ease: MOTION_EASING.standard, delay: 0.15 },
+            shouldReduceMotion
+          )}
+        >
+          <p className="battle-outcome__stat-row">
+            <span className="battle-outcome__stat-label">Enemies defeated</span>
+            <span className="battle-outcome__stat-value">{enemiesDefeated}</span>
+          </p>
+        </motion.div>
+
+        <ExpBar
+          expTotal={expTotal}
+          participantCount={participantCount}
+          reduceMotion={shouldReduceMotion}
+        />
+
+        {hasLoot && (
+          <div className="battle-outcome__loot-section">
+            <p className="battle-outcome__loot-heading">Loot</p>
+            <div className="battle-outcome__loot-grid">
+              {kranaRewards.map((r, i) => (
+                <KranaRewardCard
+                  key={`krana-${r.kranaId}-${r.element}`}
+                  reward={r}
+                  index={i}
+                  reduceMotion={shouldReduceMotion}
+                />
+              ))}
+              {kraataRewards.map((r, i) => (
+                <KraataRewardCard
+                  key={`kraata-${r.power}`}
+                  reward={r}
+                  index={i}
+                  startOffset={kranaRewards.length}
+                  reduceMotion={shouldReduceMotion}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {!hasLoot && (
+          <motion.p
+            className="battle-outcome__no-loot"
+            initial={shouldReduceMotion ? undefined : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={buildTransition(
+              { duration: MOTION_DURATION.base, ease: MOTION_EASING.standard, delay: 0.35 },
+              shouldReduceMotion
+            )}
+          >
+            No loot this time
+          </motion.p>
+        )}
+
+        <motion.button
+          className="confirm-button battle-outcome__collect"
+          onClick={onCollect}
+          initial={shouldReduceMotion ? undefined : { opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={collectTransition}
+        >
+          Collect Rewards
+        </motion.button>
+      </div>
+    </>
+  );
+}

--- a/src/pages/Battle/BattleOutcome.tsx
+++ b/src/pages/Battle/BattleOutcome.tsx
@@ -1,11 +1,20 @@
 import { motion, useReducedMotion } from 'motion/react';
 import { useMemo } from 'react';
 import { BattlePhase } from '../../hooks/useBattleState';
+import { useGame } from '../../context/Game';
 import { KRAATA_POWER_NAMES, KraataReward } from '../../types/Kraata';
 import { KranaReward } from '../../types/GameState';
-import { ELEMENT_TO_KRANA_COLOR } from '../../game/Krana';
+import type { Combatant } from '../../types/Combat';
+import type { BaseMatoran, RecruitedCharacterData } from '../../types/Matoran';
+import { ELEMENT_TO_KRANA_COLOR, ELEMENT_TO_KRANA_COLOR_HEX } from '../../game/Krana';
+import { computeBattleExpPerParticipant } from '../../game/BattleRewards';
+import { getKraataCompositedColors } from '../../data/kraataColors';
 import { buildTransition, MOTION_DURATION, MOTION_EASING } from '../../motion/transitions';
 import { isTestMode } from '../../utils/testMode';
+import { CompositedImage } from '../../components/CompositedImage';
+import { CHARACTER_DEX } from '../../data/dex/index';
+import { MatoranAvatar } from '../../components/MatoranAvatar';
+import { getLevelFromExp } from '../../game/Levelling';
 
 import './BattleOutcome.scss';
 
@@ -13,7 +22,7 @@ interface BattleOutcomeProps {
   phase: BattlePhase;
   enemiesDefeated: number;
   expTotal: number;
-  participantCount: number;
+  team: Combatant[];
   kranaRewards: KranaReward[];
   kraataRewards: KraataReward[];
   onCollect: () => void;
@@ -37,46 +46,106 @@ function OutcomeTitle({ phase }: { phase: BattlePhase }) {
   return <h1 className={className}>{label}</h1>;
 }
 
-function ExpBar({
+function ToaExpCard({
+  dex,
+  recruited,
+  expEach,
   expTotal,
-  participantCount,
+  index,
   reduceMotion,
 }: {
+  dex: BaseMatoran;
+  recruited: RecruitedCharacterData;
+  expEach: number;
   expTotal: number;
-  participantCount: number;
+  index: number;
   reduceMotion: boolean;
 }) {
-  const perToa = participantCount > 0 ? Math.floor(expTotal / participantCount) : 0;
-  const transition = buildTransition(
-    { duration: MOTION_DURATION.verySlow, ease: MOTION_EASING.standard },
+  const barTransition = buildTransition(
+    {
+      duration: MOTION_DURATION.verySlow,
+      ease: MOTION_EASING.standard,
+      delay: 0.12 + index * 0.08,
+    },
     reduceMotion
   );
+  const cardTransition = buildTransition(
+    { duration: MOTION_DURATION.slow, ease: MOTION_EASING.emphasized, delay: 0.05 + index * 0.06 },
+    reduceMotion
+  );
+
+  return (
+    <motion.div
+      className={`character-card battle-outcome__exp-toa-card element-${dex.element}`}
+      initial={reduceMotion ? undefined : { opacity: 0, y: 12, scale: 0.96 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      transition={cardTransition}
+    >
+      <MatoranAvatar
+        matoran={{ ...dex, ...recruited }}
+        styles="matoran-avatar model-preview battle-outcome__exp-toa-avatar"
+      />
+      <div className="card-header battle-outcome__exp-toa-header">
+        {dex.name}
+        <div className="level-label">Level {getLevelFromExp(recruited.exp)}</div>
+      </div>
+      <div className="battle-outcome__exp-toa-footer">
+        <span className="battle-outcome__exp-toa-amount">
+          {expEach > 0 ? `+${expEach}` : expTotal > 0 ? '+0' : '—'}
+        </span>
+        {expEach > 0 && (
+          <div className="battle-outcome__exp-toa-track">
+            <motion.div
+              className="battle-outcome__exp-toa-fill"
+              initial={{ width: '0%' }}
+              animate={{ width: '100%' }}
+              transition={barTransition}
+            />
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+function ToaExpSection({
+  team,
+  expTotal,
+  reduceMotion,
+}: {
+  team: Combatant[];
+  expTotal: number;
+  reduceMotion: boolean;
+}) {
+  const { recruitedCharacters } = useGame();
+  const expEach = useMemo(() => computeBattleExpPerParticipant(team, expTotal), [team, expTotal]);
 
   return (
     <div className="battle-outcome__exp-section">
       <div className="battle-outcome__exp-header">
         <span className="battle-outcome__exp-label">EXP earned</span>
         <span className="battle-outcome__exp-value">
-          {expTotal > 0 ? (
-            <>
-              +{expTotal}{' '}
-              {participantCount > 0 && (
-                <span className="battle-outcome__exp-per-toa">({perToa} per Toa)</span>
-              )}
-            </>
-          ) : (
-            <span className="battle-outcome__empty">0</span>
-          )}
+          {expTotal > 0 ? <>+{expTotal}</> : <span className="battle-outcome__empty">0</span>}
         </span>
       </div>
-      {expTotal > 0 && (
-        <div className="battle-outcome__exp-track">
-          <motion.div
-            className="battle-outcome__exp-fill"
-            initial={{ width: '0%' }}
-            animate={{ width: '100%' }}
-            transition={transition}
-          />
+      {team.length > 0 && (
+        <div className="battle-outcome__exp-team">
+          {team.map((combatant, index) => {
+            const recruited = recruitedCharacters.find((r) => r.id === combatant.id);
+            const dex = CHARACTER_DEX[combatant.id];
+            if (!dex || !recruited) return null;
+            return (
+              <ToaExpCard
+                key={`${combatant.id}-${index}`}
+                dex={dex}
+                recruited={recruited}
+                expEach={expEach}
+                expTotal={expTotal}
+                index={index}
+                reduceMotion={reduceMotion}
+              />
+            );
+          })}
         </div>
       )}
     </div>
@@ -109,11 +178,13 @@ function KranaRewardCard({
       animate={{ opacity: 1, y: 0, scale: 1 }}
       transition={transition}
     >
-      <img
-        src={`${import.meta.env.BASE_URL}/avatar/Krana/${reward.kranaId}.webp`}
-        alt={`Krana ${reward.kranaId}`}
-        className="battle-outcome__loot-img"
-      />
+      <div className="battle-outcome__loot-krana-img-wrap">
+        <CompositedImage
+          images={[`${import.meta.env.BASE_URL}/avatar/Krana/${reward.kranaId}.webp`]}
+          colors={[ELEMENT_TO_KRANA_COLOR_HEX[reward.element]]}
+          className="battle-outcome__loot-img"
+        />
+      </div>
       <span className="battle-outcome__loot-label">
         Krana {reward.kranaId}
         <span className="battle-outcome__loot-element">{reward.element}</span>
@@ -150,10 +221,21 @@ function KraataRewardCard({
       animate={{ opacity: 1, y: 0, scale: 1 }}
       transition={transition}
     >
-      <span className="battle-outcome__loot-icon">🐛</span>
+      <CompositedImage
+        images={[
+          `${import.meta.env.BASE_URL}/avatar/Kraata/${reward.stage}_Base.webp`,
+          `${import.meta.env.BASE_URL}/avatar/Kraata/${reward.stage}_Head.webp`,
+          `${import.meta.env.BASE_URL}/avatar/Kraata/${reward.stage}_Tail.webp`,
+        ]}
+        colors={getKraataCompositedColors(reward.power)}
+        className="battle-outcome__loot-kraata"
+      />
       <span className="battle-outcome__loot-label">
-        Kraata of {label}
-        {reward.qty > 1 && <span className="battle-outcome__loot-qty">x{reward.qty}</span>}
+        <span className="battle-outcome__loot-kraata-title">{label}</span>
+        <span className="battle-outcome__loot-kraata-meta">
+          <span className="battle-outcome__loot-kraata-stage bionicle-font">{reward.stage}</span>
+          {reward.qty > 1 && <span className="battle-outcome__loot-qty">×{reward.qty}</span>}
+        </span>
       </span>
     </motion.div>
   );
@@ -163,7 +245,7 @@ export function BattleOutcome({
   phase,
   enemiesDefeated,
   expTotal,
-  participantCount,
+  team,
   kranaRewards,
   kraataRewards,
   onCollect,
@@ -223,33 +305,31 @@ export function BattleOutcome({
           </p>
         </motion.div>
 
-        <ExpBar
-          expTotal={expTotal}
-          participantCount={participantCount}
-          reduceMotion={shouldReduceMotion}
-        />
+        <ToaExpSection team={team} expTotal={expTotal} reduceMotion={shouldReduceMotion} />
 
         {hasLoot && (
           <div className="battle-outcome__loot-section">
             <p className="battle-outcome__loot-heading">Loot</p>
-            <div className="battle-outcome__loot-grid">
-              {kranaRewards.map((r, i) => (
-                <KranaRewardCard
-                  key={`krana-${r.kranaId}-${r.element}`}
-                  reward={r}
-                  index={i}
-                  reduceMotion={shouldReduceMotion}
-                />
-              ))}
-              {kraataRewards.map((r, i) => (
-                <KraataRewardCard
-                  key={`kraata-${r.power}`}
-                  reward={r}
-                  index={i}
-                  startOffset={kranaRewards.length}
-                  reduceMotion={shouldReduceMotion}
-                />
-              ))}
+            <div className="battle-outcome__loot-scroll">
+              <div className="battle-outcome__loot-grid">
+                {kranaRewards.map((r, i) => (
+                  <KranaRewardCard
+                    key={`krana-${r.kranaId}-${r.element}`}
+                    reward={r}
+                    index={i}
+                    reduceMotion={shouldReduceMotion}
+                  />
+                ))}
+                {kraataRewards.map((r, i) => (
+                  <KraataRewardCard
+                    key={`kraata-${r.power}-${r.stage}-${i}`}
+                    reward={r}
+                    index={i}
+                    startOffset={kranaRewards.length}
+                    reduceMotion={shouldReduceMotion}
+                  />
+                ))}
+              </div>
             </div>
           </div>
         )}

--- a/src/pages/Battle/Cards/Ally.tsx
+++ b/src/pages/Battle/Cards/Ally.tsx
@@ -6,6 +6,7 @@ import { HpBar } from '../../../components/HpBar';
 import { CHARACTER_DEX } from '../../../data/dex/index';
 import { MatoranAvatar } from '../../../components/MatoranAvatar';
 import { MaskPowerTooltip } from '../../../components/MaskPowerTooltip';
+import { MaskActivationBurst } from './MaskActivationBurst';
 
 export function AllyCard({
   combatant,
@@ -88,6 +89,7 @@ export function AllyCard({
           maskPowerActive={maskActive}
         />
       </MaskPowerTooltip>
+      <MaskActivationBurst active={maskActive} elementClass={`element-${dex.element}`} />
       <div className="card-header">
         {dex.name}
         <div className="level-label">Level {combatant.lvl}</div>
@@ -101,11 +103,7 @@ export function AllyCard({
         ></div>
       )}
       <div className="hp-bar-host">
-        <HpBar
-          hp={combatant.hp}
-          maxHp={combatant.maxHp}
-          defeated={combatant.hp <= 0}
-        />
+        <HpBar hp={combatant.hp} maxHp={combatant.maxHp} defeated={combatant.hp <= 0} />
         {damage && (
           <DamagePopup
             popup={damage}

--- a/src/pages/Battle/Cards/MaskActivationBurst.scss
+++ b/src/pages/Battle/Cards/MaskActivationBurst.scss
@@ -1,0 +1,69 @@
+$particle-count: 12;
+$burst-duration: 700ms;
+
+.mask-burst {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 3;
+  overflow: visible;
+
+  &__particle {
+    --angle: calc(var(--i) * (360deg / #{$particle-count}));
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--theme-element-glow);
+    box-shadow:
+      0 0 6px var(--theme-element-glow),
+      0 0 12px var(--theme-element-glow-transparent);
+    transform: translate(-50%, -50%) rotate(var(--angle)) translateY(0);
+    animation: mask-burst-fly $burst-duration cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  }
+
+  &__ring {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 20px;
+    height: 20px;
+    border: 2px solid var(--theme-element-glow);
+    border-radius: 50%;
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0.8;
+    animation: mask-burst-ring $burst-duration cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  }
+}
+
+@keyframes mask-burst-fly {
+  0% {
+    transform: translate(-50%, -50%) rotate(var(--angle)) translateY(0);
+    opacity: 1;
+  }
+  60% {
+    opacity: 0.8;
+  }
+  100% {
+    transform: translate(-50%, -50%) rotate(var(--angle)) translateY(-50px);
+    opacity: 0;
+  }
+}
+
+@keyframes mask-burst-ring {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0.9;
+    border-width: 3px;
+  }
+  70% {
+    opacity: 0.4;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(5);
+    opacity: 0;
+    border-width: 1px;
+  }
+}

--- a/src/pages/Battle/Cards/MaskActivationBurst.tsx
+++ b/src/pages/Battle/Cards/MaskActivationBurst.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react';
+import { useReducedMotion } from 'motion/react';
+import { isTestMode } from '../../../utils/testMode';
+
+import './MaskActivationBurst.scss';
+
+const PARTICLE_COUNT = 12;
+const BURST_DURATION_MS = 700;
+
+export function MaskActivationBurst({
+  active,
+  elementClass,
+}: {
+  active: boolean;
+  elementClass: string;
+}) {
+  const shouldReduceMotion = (useReducedMotion() ?? false) || isTestMode();
+  const [bursting, setBursting] = useState(false);
+  const prevActiveRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (active && !prevActiveRef.current && !shouldReduceMotion) {
+      setBursting(true);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        setBursting(false);
+        timerRef.current = null;
+      }, BURST_DURATION_MS);
+    }
+    prevActiveRef.current = active;
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [active, shouldReduceMotion]);
+
+  if (!bursting) return null;
+
+  return (
+    <div className={`mask-burst ${elementClass}`} aria-hidden="true">
+      {Array.from({ length: PARTICLE_COUNT }, (_, i) => (
+        <span
+          key={i}
+          className="mask-burst__particle"
+          style={{ '--i': i } as React.CSSProperties}
+        />
+      ))}
+      <span className="mask-burst__ring" />
+    </div>
+  );
+}

--- a/src/pages/Battle/index.tsx
+++ b/src/pages/Battle/index.tsx
@@ -103,8 +103,6 @@ export const BattlePage: React.FC = () => {
       currentEncounter && getEnemiesDefeatedCount(currentEncounter, phase, currentWave, enemies);
     const expTotal =
       currentEncounter && computeBattleExpTotal(currentEncounter, phase, currentWave, enemies);
-    const participantCount = team.length;
-
     const handleCollectRewards = () => {
       if (currentEncounter) {
         applyBattleRewards({
@@ -127,7 +125,7 @@ export const BattlePage: React.FC = () => {
           phase={phase}
           enemiesDefeated={enemiesDefeated ?? 0}
           expTotal={expTotal ?? 0}
-          participantCount={participantCount}
+          team={team}
           kranaRewards={kranaRewards}
           kraataRewards={kraataRewards}
           onCollect={handleCollectRewards}

--- a/src/pages/Battle/index.tsx
+++ b/src/pages/Battle/index.tsx
@@ -4,6 +4,7 @@ import { BattlePhase } from '../../hooks/useBattleState';
 import { useEffect, useRef } from 'react';
 import { BattleInProgress } from './InProgress';
 import { BattlePrep } from './Prep';
+import { BattleOutcome } from './BattleOutcome';
 import { useBattlePageHitFeedback } from './useBattlePageHitFeedback';
 import { useSceneCanvas } from '../../hooks/useSceneCanvas';
 import { Arena } from './Arena';
@@ -13,7 +14,7 @@ import {
   computeKranaRewardsForBattle,
   computeKraataRewardsForBattle,
 } from '../../game/BattleRewards';
-import { KRAATA_POWER_NAMES, KraataReward } from '../../types/Kraata';
+import { KraataReward } from '../../types/Kraata';
 
 export const BattlePage: React.FC = () => {
   const navigate = useNavigate();
@@ -122,51 +123,18 @@ export const BattlePage: React.FC = () => {
 
     return (
       <div className={`${battlePageRootClass} page-container battle battle--outcome`}>
-        <h1 className="battle-outcome__title">{phase}</h1>
-        <div className="battle-arena"></div>
-        <div className="battle-rewards-panel">
-          <p className="battle-rewards-panel__row">Enemies defeated: {enemiesDefeated ?? 0}</p>
-          <p className="battle-rewards-panel__row battle-rewards-panel__exp">
-            {expTotal !== undefined && expTotal > 0 ? (
-              <>
-                EXP earned: {expTotal} total
-                {participantCount > 0 && <> ({Math.floor(expTotal / participantCount)} per Toa)</>}
-              </>
-            ) : (
-              <span className="battle-rewards-panel__empty">EXP earned: 0</span>
-            )}
-          </p>
-          <p className="battle-rewards-panel__row battle-rewards-panel__krana">
-            Krana recovered:{' '}
-            {kranaRewards.length > 0 ? (
-              kranaRewards.map((r) => `${r.kranaId} (${r.element})`).join(', ')
-            ) : (
-              <span className="battle-rewards-panel__empty">None</span>
-            )}
-          </p>
-          {kraataRewards.length > 0 && (
-            <p className="battle-rewards-panel__row battle-rewards-panel__items">
-              Kraata found:{' '}
-              {kraataRewards
-                .map((r) => {
-                  const label = `Kraata of ${KRAATA_POWER_NAMES[r.power] ?? r.power}`;
-                  return r.qty > 1 ? `${label} x${r.qty}` : label;
-                })
-                .join(', ')}
-            </p>
-          )}
-          <button
-            className="confirm-button battle-rewards-panel__collect"
-            onClick={handleCollectRewards}
-          >
-            Collect Rewards
-          </button>
-        </div>
+        <BattleOutcome
+          phase={phase}
+          enemiesDefeated={enemiesDefeated ?? 0}
+          expTotal={expTotal ?? 0}
+          participantCount={participantCount}
+          kranaRewards={kranaRewards}
+          kraataRewards={kraataRewards}
+          onCollect={handleCollectRewards}
+        />
       </div>
     );
   }
 
-  return (
-    <div className={`${battlePageRootClass} page-container`}>Battle status: {phase}</div>
-  );
+  return <div className={`${battlePageRootClass} page-container`}>Battle status: {phase}</div>;
 };

--- a/src/pages/CharacterDetail/KranaCollection/index.scss
+++ b/src/pages/CharacterDetail/KranaCollection/index.scss
@@ -55,13 +55,16 @@
 }
 
 .krana-collection__img-wrap {
-  position: relative;
   width: 100%;
   height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
   background: var(--color-surface-mid, #2a2a2a);
+}
+
+.krana-collection__img-wrap {
+  position: relative;
 
   &::after {
     content: '';

--- a/src/styles/battle.scss
+++ b/src/styles/battle.scss
@@ -149,53 +149,12 @@
   }
 }
 
-// Rewards collection panel – centered card with background, consistent layout
 .battle--outcome {
   display: flex;
   flex-direction: column;
   align-items: center;
   padding-top: 1.5rem;
   justify-content: space-between;
-
-  .battle-outcome__title {
-    font-size: 8vw;
-    margin-bottom: 1.5rem;
-  }
-}
-
-.battle-rewards-panel {
-  width: 100%;
-  max-width: 420px;
-  padding: 1.5rem 2rem;
-  background-color: var(--color-surface-high);
-  border: 1px solid var(--color-border-muted);
-  border-radius: var(--border-radius-lg);
-  box-shadow: var(--shadow-lg), var(--shadow-glow);
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  position: fixed;
-  bottom: 180px;
-
-  &__row {
-    margin: 0;
-    min-height: 1.5em;
-    font-size: 1rem;
-  }
-
-  &__exp,
-  &__krana {
-    flex-shrink: 0;
-  }
-
-  &__empty {
-    color: var(--color-text-secondary);
-    font-style: italic;
-  }
-
-  &__collect {
-    margin-top: 0.5rem;
-  }
 }
 
 @keyframes battle-arena-wave-clear {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Completes the two remaining Phase 0 items from `UI_UX_STRATEGY.md`:

## Mask Activation Particle Burst

New `MaskActivationBurst` component renders a CSS-based elemental particle burst when a mask power activates during combat. 12 particles radiate outward from the card center, colored by the combatant's element theme variables (`--theme-element-glow`), accompanied by an expanding ring. Respects `prefers-reduced-motion` and test mode.

[Mask power activated on Toa Gali with elemental glow](https://cursor.com/agents/bc-ee865cab-8c93-4fa0-a64b-aa834ed11bb3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmask_activation_glow.webp)

## Battle Outcome Screen

Extracted the inline outcome rendering from `BattlePage` into a dedicated `BattleOutcome` component with:

- **Styled title** — "Victory!" in gold with text-shadow glow, "Defeat" in red, "Retreated" in muted gray
- **Stats row** — enemies defeated count with label/value layout  
- **Animated EXP bar** — fills from 0% to 100% with a gold gradient, using `motion/react` transitions
- **Staggered loot cards** — krana and kraata rewards animate in one-by-one with spring physics (scale + fade + slide up), delayed by index
- **"No loot" state** — italic message when no drops occurred
- **Collect Rewards button** — fades in after all loot cards have appeared

[Victory outcome screen with EXP bar and loot cards](https://cursor.com/agents/bc-ee865cab-8c93-4fa0-a64b-aa834ed11bb3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvictory_outcome_screen.webp)
[Defeat outcome screen](https://cursor.com/agents/bc-ee865cab-8c93-4fa0-a64b-aa834ed11bb3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdefeat_outcome_screen.webp)

## Files changed

| File | Change |
|------|--------|
| `src/pages/Battle/Cards/MaskActivationBurst.tsx` | New — particle burst component |
| `src/pages/Battle/Cards/MaskActivationBurst.scss` | New — particle + ring keyframe animations |
| `src/pages/Battle/Cards/Ally.tsx` | Integrate `MaskActivationBurst` into ally cards |
| `src/pages/Battle/BattleOutcome.tsx` | New — animated outcome screen component |
| `src/pages/Battle/BattleOutcome.scss` | New — outcome screen styles |
| `src/pages/Battle/index.tsx` | Use `BattleOutcome` instead of inline rendering |
| `src/styles/battle.scss` | Remove old `.battle-rewards-panel` styles |
| `docs/UI_UX_STRATEGY.md` | Mark both Phase 0 items as complete |

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee865cab-8c93-4fa0-a64b-aa834ed11bb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee865cab-8c93-4fa0-a64b-aa834ed11bb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

