### PR TITLE
fix(battle): unblock combat when Attack animation is missing

### DIFF
--- a/src/hooks/usePlayAnimation.spec.tsx
+++ b/src/hooks/usePlayAnimation.spec.tsx
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock('@react-three/fiber', () => ({
+  useFrame: jest.fn(),
+}));
+
+import { act, useMemo } from 'react';
+import { renderHook } from '@testing-library/react';
+import { AnimationMixer, Group } from 'three';
+import type { AnimationAction } from 'three';
+import { usePlayAnimation } from './usePlayAnimation';
+
+describe('usePlayAnimation', () => {
+  it('calls onAnimationComplete when the Attack clip is missing so combat can unblock', async () => {
+    const onComplete = jest.fn();
+
+    const { result } = renderHook(() => {
+      const mixer = useMemo(() => new AnimationMixer(new Group()), []);
+      const actions = useMemo<Record<string, AnimationAction | null>>(
+        () => ({ Attack: null, Idle: null }),
+        []
+      );
+      return usePlayAnimation(actions, mixer);
+    });
+
+    await act(async () => {
+      await result.current('Attack', { onAnimationComplete: onComplete });
+    });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/usePlayAnimation.ts
+++ b/src/hooks/usePlayAnimation.ts
@@ -62,7 +62,11 @@ export function usePlayAnimation(
           if (modelId) {
             console.warn(`Animation '${name}' not found for ${modelId}`);
           }
-          return resolve();
+          // Outer CombatantModel waits for onAnimationComplete to resolve waitForAttackComplete;
+          // fire it when there is no clip so combat does not hang.
+          callOptions?.onAnimationComplete?.();
+          resolve();
+          return;
         }
 
         if (transitionMode === 'stopAll') {

--- a/src/pages/Battle/CombatantModel.tsx
+++ b/src/pages/Battle/CombatantModel.tsx
@@ -135,7 +135,7 @@ export const CombatantModel = forwardRef<CombatantModelHandle, CombatantModelPro
         };
 
         if (name === 'Attack') {
-          let resolveComplete: () => void;
+          let resolveComplete!: () => void;
           attackCompleteRef.current = new Promise<void>((r) => {
             resolveComplete = r;
           });

--- a/src/pages/Battle/CombatantModel.tsx
+++ b/src/pages/Battle/CombatantModel.tsx
@@ -146,6 +146,11 @@ export const CombatantModel = forwardRef<CombatantModelHandle, CombatantModelPro
             },
           };
           await (childRef.current?.playAnimation(name, callOptions) ?? Promise.resolve());
+          // No inner model (unknown combatant.model): nothing runs onAnimationComplete.
+          if (!childRef.current) {
+            startRestore();
+            resolveComplete();
+          }
           return;
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Combat could hang after an attack because `combatUtils` awaits `Promise.all` including `waitForAttackComplete()`, which only resolved when the inner model called `onAnimationComplete` after the Attack clip finished. If the GLB had no Attack clip, `usePlayAnimation` returned immediately without ever firing that callback, so the promise never settled.

## Changes

- **`usePlayAnimation`**: When the requested clip is missing, call `onAnimationComplete` before resolving (same timing as “no animation” — immediate).
- **`CombatantModel`**: When there is no inner model (`combatant.model` falls through to `null`), resolve attack completion after the no-op `playAnimation` await so `waitForAttackComplete` does not wait forever.
- **Test**: `usePlayAnimation.spec.tsx` (jsdom + mocked `useFrame`) asserts `onAnimationComplete` runs for missing Attack.

## Verification

- `yarn lint`
- `yarn test:ci`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3217350-27fb-4bd7-ac55-e6f5018b6fa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3217350-27fb-4bd7-ac55-e6f5018b6fa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

