### PR TITLE
feat(battle): procedural default combat motion for missing GLB clips

### DIFF
--- a/src/components/CharacterScene/Nuva/GaliNuvaModel.tsx
+++ b/src/components/CharacterScene/Nuva/GaliNuvaModel.tsx
@@ -1,11 +1,11 @@
 import { useGLTF } from '@react-three/drei';
 import { CombatantModelHandle } from '../../../pages/Battle/CombatantModel';
 import { BaseMatoran, RecruitedCharacterData } from '../../../types/Matoran';
-import { forwardRef, useEffect, useRef } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import { Group } from 'three';
 import { useArmor } from '../../../hooks/useArmor';
 import { useNuvaMask } from '../../../hooks/useNuvaMask';
-import { useIdleAnimation } from '../../../hooks/useIdleAnimation';
+import { useCombatAnimations } from '../../../hooks/useCombatAnimations';
 import { applyWeatheredMetalToObject } from '../WeatheredMetalMaterial';
 
 const USE_WEATHERED_METAL = true;
@@ -15,11 +15,16 @@ export const GaliNuvaModel = forwardRef<
   {
     matoran: RecruitedCharacterData & BaseMatoran & { maskPowerActive?: boolean };
   }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
->(({ matoran }, _ref) => {
+>(({ matoran }, ref) => {
   const group = useRef<Group>(null);
   const { nodes, animations } = useGLTF(import.meta.env.BASE_URL + 'Toa_Nuva/gali.glb');
-  useIdleAnimation(animations, group);
+
+  const { playAnimation } = useCombatAnimations(animations, group, {
+    modelId: matoran.id,
+    attackResolveAtFraction: 0.5,
+  });
+
+  useImperativeHandle(ref, () => ({ playAnimation }));
 
   useEffect(() => {
     const root = group.current;

--- a/src/components/CharacterScene/Nuva/KopakaNuvaModel.tsx
+++ b/src/components/CharacterScene/Nuva/KopakaNuvaModel.tsx
@@ -1,11 +1,11 @@
 import { useGLTF } from '@react-three/drei';
 import { CombatantModelHandle } from '../../../pages/Battle/CombatantModel';
 import { BaseMatoran, RecruitedCharacterData } from '../../../types/Matoran';
-import { forwardRef, useEffect, useRef } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import { Group } from 'three';
 import { useArmor } from '../../../hooks/useArmor';
 import { useNuvaMask } from '../../../hooks/useNuvaMask';
-import { useIdleAnimation } from '../../../hooks/useIdleAnimation';
+import { useCombatAnimations } from '../../../hooks/useCombatAnimations';
 import { applyWeatheredMetalToObject } from '../WeatheredMetalMaterial';
 
 const USE_WEATHERED_METAL = true;
@@ -15,11 +15,16 @@ export const KopakaNuvaModel = forwardRef<
   {
     matoran: RecruitedCharacterData & BaseMatoran & { maskPowerActive?: boolean };
   }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
->(({ matoran }, _ref) => {
+>(({ matoran }, ref) => {
   const group = useRef<Group>(null);
   const { nodes, animations } = useGLTF(import.meta.env.BASE_URL + 'Toa_Nuva/kopaka.glb');
-  useIdleAnimation(animations, group);
+
+  const { playAnimation } = useCombatAnimations(animations, group, {
+    modelId: matoran.id,
+    attackResolveAtFraction: 0.5,
+  });
+
+  useImperativeHandle(ref, () => ({ playAnimation }));
 
   useEffect(() => {
     const root = group.current;

--- a/src/components/CharacterScene/Nuva/LewaNuvaModel.tsx
+++ b/src/components/CharacterScene/Nuva/LewaNuvaModel.tsx
@@ -1,11 +1,11 @@
 import { useGLTF } from '@react-three/drei';
 import { CombatantModelHandle } from '../../../pages/Battle/CombatantModel';
 import { BaseMatoran, RecruitedCharacterData } from '../../../types/Matoran';
-import { forwardRef, useEffect, useRef } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import { Group } from 'three';
 import { useArmor } from '../../../hooks/useArmor';
 import { useNuvaMask } from '../../../hooks/useNuvaMask';
-import { useIdleAnimation } from '../../../hooks/useIdleAnimation';
+import { useCombatAnimations } from '../../../hooks/useCombatAnimations';
 import { applyWeatheredMetalToObject } from '../WeatheredMetalMaterial';
 
 const USE_WEATHERED_METAL = true;
@@ -15,11 +15,16 @@ export const LewaNuvaModel = forwardRef<
   {
     matoran: RecruitedCharacterData & BaseMatoran & { maskPowerActive?: boolean };
   }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
->(({ matoran }, _ref) => {
+>(({ matoran }, ref) => {
   const group = useRef<Group>(null);
   const { nodes, animations } = useGLTF(import.meta.env.BASE_URL + 'Toa_Nuva/lewa.glb');
-  useIdleAnimation(animations, group);
+
+  const { playAnimation } = useCombatAnimations(animations, group, {
+    modelId: matoran.id,
+    attackResolveAtFraction: 0.5,
+  });
+
+  useImperativeHandle(ref, () => ({ playAnimation }));
 
   useEffect(() => {
     const root = group.current;

--- a/src/components/CharacterScene/Nuva/OnuaNuvaModel.tsx
+++ b/src/components/CharacterScene/Nuva/OnuaNuvaModel.tsx
@@ -1,11 +1,11 @@
 import { useGLTF } from '@react-three/drei';
 import { CombatantModelHandle } from '../../../pages/Battle/CombatantModel';
 import { BaseMatoran, RecruitedCharacterData } from '../../../types/Matoran';
-import { forwardRef, useEffect, useRef } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import { Group } from 'three';
 import { useArmor } from '../../../hooks/useArmor';
 import { useNuvaMask } from '../../../hooks/useNuvaMask';
-import { useIdleAnimation } from '../../../hooks/useIdleAnimation';
+import { useCombatAnimations } from '../../../hooks/useCombatAnimations';
 import { applyWeatheredMetalToObject } from '../WeatheredMetalMaterial';
 
 const USE_WEATHERED_METAL = true;
@@ -15,11 +15,16 @@ export const OnuaNuvaModel = forwardRef<
   {
     matoran: RecruitedCharacterData & BaseMatoran & { maskPowerActive?: boolean };
   }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
->(({ matoran }, _ref) => {
+>(({ matoran }, ref) => {
   const group = useRef<Group>(null);
   const { nodes, animations } = useGLTF(import.meta.env.BASE_URL + 'Toa_Nuva/onua.glb');
-  useIdleAnimation(animations, group);
+
+  const { playAnimation } = useCombatAnimations(animations, group, {
+    modelId: matoran.id,
+    attackResolveAtFraction: 0.5,
+  });
+
+  useImperativeHandle(ref, () => ({ playAnimation }));
 
   useEffect(() => {
     const root = group.current;

--- a/src/components/CharacterScene/Nuva/PohatuNuvaModel.tsx
+++ b/src/components/CharacterScene/Nuva/PohatuNuvaModel.tsx
@@ -1,11 +1,11 @@
 import { useGLTF } from '@react-three/drei';
 import { CombatantModelHandle } from '../../../pages/Battle/CombatantModel';
 import { BaseMatoran, RecruitedCharacterData } from '../../../types/Matoran';
-import { forwardRef, useEffect, useRef } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import { Group } from 'three';
 import { useArmor } from '../../../hooks/useArmor';
 import { useNuvaMask } from '../../../hooks/useNuvaMask';
-import { useIdleAnimation } from '../../../hooks/useIdleAnimation';
+import { useCombatAnimations } from '../../../hooks/useCombatAnimations';
 import { applyWeatheredMetalToObject } from '../WeatheredMetalMaterial';
 
 const USE_WEATHERED_METAL = true;
@@ -15,11 +15,16 @@ export const PohatuNuvaModel = forwardRef<
   {
     matoran: RecruitedCharacterData & BaseMatoran & { maskPowerActive?: boolean };
   }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
->(({ matoran }, _ref) => {
+>(({ matoran }, ref) => {
   const group = useRef<Group>(null);
   const { nodes, animations } = useGLTF(import.meta.env.BASE_URL + 'Toa_Nuva/pohatu.glb');
-  useIdleAnimation(animations, group);
+
+  const { playAnimation } = useCombatAnimations(animations, group, {
+    modelId: matoran.id,
+    attackResolveAtFraction: 0.5,
+  });
+
+  useImperativeHandle(ref, () => ({ playAnimation }));
 
   useEffect(() => {
     const root = group.current;

--- a/src/components/CharacterScene/Nuva/TakanuvaModel.tsx
+++ b/src/components/CharacterScene/Nuva/TakanuvaModel.tsx
@@ -1,10 +1,10 @@
 import { useGLTF } from '@react-three/drei';
 import { CombatantModelHandle } from '../../../pages/Battle/CombatantModel';
 import { BaseMatoran, RecruitedCharacterData } from '../../../types/Matoran';
-import { forwardRef, useEffect, useRef } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import { Group } from 'three';
 import { useArmor } from '../../../hooks/useArmor';
-import { useIdleAnimation } from '../../../hooks/useIdleAnimation';
+import { useCombatAnimations } from '../../../hooks/useCombatAnimations';
 import { applyWeatheredMetalToObject } from '../WeatheredMetalMaterial';
 
 const USE_WEATHERED_METAL = true;
@@ -14,11 +14,16 @@ export const TakanuvaModel = forwardRef<
   {
     matoran: RecruitedCharacterData & BaseMatoran & { maskPowerActive?: boolean };
   }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
->(({ matoran }, _ref) => {
+>(({ matoran }, ref) => {
   const group = useRef<Group>(null);
   const { nodes, animations } = useGLTF(import.meta.env.BASE_URL + 'Toa_Nuva/takanuva.glb');
-  useIdleAnimation(animations, group);
+
+  const { playAnimation } = useCombatAnimations(animations, group, {
+    modelId: matoran.id,
+    attackResolveAtFraction: 0.5,
+  });
+
+  useImperativeHandle(ref, () => ({ playAnimation }));
 
   useEffect(() => {
     const root = group.current;

--- a/src/hooks/useCombatAnimations.spec.tsx
+++ b/src/hooks/useCombatAnimations.spec.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock('@react-three/fiber', () => ({
+  useFrame: jest.fn(),
+}));
+
+const playProceduralCombatAnimation = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('./useModelProceduralCombatMotion', () => ({
+  useModelProceduralCombatMotion: () => ({ playProceduralCombatAnimation }),
+}));
+
+jest.mock('./useIdleAnimation', () => ({
+  useIdleAnimation: () => ({
+    actions: {
+      Idle: null,
+      Attack: null,
+      Hit: null,
+      Defeat: null,
+    },
+    mixer: {
+      stopAllAction: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    },
+  }),
+}));
+
+jest.mock('./usePlayAnimation', () => ({
+  usePlayAnimation: () => jest.fn().mockResolvedValue(undefined),
+}));
+
+import { act, renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+import { Group } from 'three';
+import { useCombatAnimations } from './useCombatAnimations';
+
+describe('useCombatAnimations', () => {
+  beforeEach(() => {
+    playProceduralCombatAnimation.mockClear();
+  });
+
+  it('uses procedural combat motion when GLB clips are missing', async () => {
+    const { result } = renderHook(() => {
+      const groupRef = useRef<Group | null>(null);
+      return useCombatAnimations([], groupRef, { modelId: 'test-toa' });
+    });
+
+    await act(async () => {
+      await result.current.playAnimation('Attack');
+    });
+
+    expect(playProceduralCombatAnimation).toHaveBeenCalledWith(
+      'Attack',
+      expect.objectContaining({ onAnimationComplete: expect.any(Function) })
+    );
+  });
+});

--- a/src/hooks/useCombatAnimations.ts
+++ b/src/hooks/useCombatAnimations.ts
@@ -1,23 +1,93 @@
-import type { RefObject } from 'react';
+import { useCallback, type RefObject } from 'react';
 import type { AnimationClip, Group } from 'three';
 import { useIdleAnimation } from './useIdleAnimation';
-import { usePlayAnimation, type UsePlayAnimationOptions } from './usePlayAnimation';
+import {
+  usePlayAnimation,
+  type PlayAnimationCallOptions,
+  type UsePlayAnimationOptions,
+} from './usePlayAnimation';
+import { useModelProceduralCombatMotion } from './useModelProceduralCombatMotion';
 
 export type UseCombatAnimationsOptions = UsePlayAnimationOptions;
 
 /**
  * Convenience hook that composes useIdleAnimation + usePlayAnimation.
  * Use for combat models (Tahu, Gali, Bohrok, etc.) that need both idle and playAnimation.
+ * When Attack/Hit/Defeat clips are missing from the GLB, applies the same procedural root
+ * motion timing as Rahi placeholders (lunge / shake / knockdown).
  */
 export function useCombatAnimations(
   animations: AnimationClip[],
   groupRef: RefObject<Group | null>,
   options: UseCombatAnimationsOptions = {}
 ) {
+  const { idleActionName = 'Idle', transitionMode = 'fadeIdle' } = options;
+
   const { actions, mixer } = useIdleAnimation(animations, groupRef, {
     idleActionName: options.idleActionName,
   });
-  const playAnimation = usePlayAnimation(actions, mixer, options);
+  const basePlay = usePlayAnimation(actions, mixer, options);
+  const { playProceduralCombatAnimation } = useModelProceduralCombatMotion(groupRef);
+
+  const playAnimation = useCallback(
+    async (name: string, callOptions?: PlayAnimationCallOptions) => {
+      const isCombatMotion = name === 'Attack' || name === 'Hit' || name === 'Defeat';
+      if (!isCombatMotion) {
+        return basePlay(name, callOptions);
+      }
+
+      const action = actions[name];
+      const hasClip = !!action;
+
+      const fadeOutIdleForProcedural = () => {
+        if (transitionMode === 'stopAll') {
+          mixer.stopAllAction();
+        } else {
+          actions[idleActionName]?.fadeOut(0.2);
+        }
+      };
+
+      if (name === 'Attack') {
+        if (hasClip) {
+          await basePlay(name, callOptions);
+        } else {
+          fadeOutIdleForProcedural();
+          await playProceduralCombatAnimation('Attack', {
+            ...callOptions,
+            onAnimationComplete: () => {
+              const idle = actions[idleActionName];
+              if (idle) {
+                idle.reset().fadeIn(0.2).play();
+              }
+              callOptions?.onAnimationComplete?.();
+            },
+          });
+        }
+        return;
+      }
+
+      if (hasClip) {
+        await basePlay(name, callOptions);
+      } else {
+        fadeOutIdleForProcedural();
+        await playProceduralCombatAnimation(name as 'Hit' | 'Defeat', callOptions);
+        if (name === 'Hit') {
+          const idle = actions[idleActionName];
+          if (idle) {
+            idle.reset().fadeIn(0.2).play();
+          }
+        }
+      }
+    },
+    [
+      actions,
+      basePlay,
+      idleActionName,
+      mixer,
+      playProceduralCombatAnimation,
+      transitionMode,
+    ]
+  );
 
   return { playAnimation };
 }

--- a/src/hooks/useModelProceduralCombatMotion.spec.tsx
+++ b/src/hooks/useModelProceduralCombatMotion.spec.tsx
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock('@react-three/fiber', () => ({
+  useFrame: jest.fn(),
+}));
+
+import { act, renderHook } from '@testing-library/react';
+import { Group } from 'three';
+import { useModelProceduralCombatMotion } from './useModelProceduralCombatMotion';
+
+describe('useModelProceduralCombatMotion', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('fires onAnimationComplete after procedural Attack total duration', async () => {
+    const rootRef = { current: new Group() };
+    const onComplete = jest.fn();
+
+    const { result } = renderHook(() => useModelProceduralCombatMotion(rootRef));
+
+    let attackPromise: Promise<void>;
+    await act(async () => {
+      attackPromise = result.current.playProceduralCombatAnimation('Attack', {
+        onAnimationComplete: onComplete,
+      });
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+
+    // Contact delay, then full-attack timer before onAnimationComplete.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(140 + 420);
+    });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await attackPromise!;
+    });
+  });
+});

--- a/src/hooks/useModelProceduralCombatMotion.ts
+++ b/src/hooks/useModelProceduralCombatMotion.ts
@@ -1,0 +1,91 @@
+import { useCallback, useRef, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import type { RefObject } from 'react';
+import type { Group } from 'three';
+import type { PlayAnimationCallOptions } from './usePlayAnimation';
+
+/** Match RahiPlaceholderModel / NuiRamaModel timing for consistent combat pacing. */
+const ATTACK_CONTACT_MS = 140;
+const ATTACK_TOTAL_MS = 420;
+const HIT_MS = 280;
+const DEFEAT_MS = 600;
+
+type CombatAnim = 'idle' | 'attack' | 'hit' | 'defeat';
+
+/**
+ * Subtle root motion when a GLB has no Attack/Hit/Defeat clips. Keeps the same
+ * playAnimation timing contract as clip-based models (contact vs full Attack).
+ */
+export function useModelProceduralCombatMotion(rootRef: RefObject<Group | null>) {
+  const [anim, setAnim] = useState<CombatAnim>('idle');
+  const animStartRef = useRef(0);
+
+  useFrame((state) => {
+    const g = rootRef.current;
+    if (!g) return;
+
+    if (anim === 'idle') {
+      // Do not fight GLB idle: only clear offsets we may have applied.
+      g.position.z = 0;
+      g.rotation.x = 0;
+      g.rotation.z = 0;
+      return;
+    }
+
+    const t = state.clock.elapsedTime;
+    const elapsed = (performance.now() - animStartRef.current) / 1000;
+
+    if (anim === 'attack') {
+      const punch = Math.min(1, elapsed / (ATTACK_TOTAL_MS / 1000));
+      const lunge = Math.sin(punch * Math.PI) * 0.35;
+      g.position.z = lunge;
+      g.position.y = Math.sin(t * 2.2) * 0.02;
+    } else if (anim === 'hit') {
+      g.rotation.z = Math.sin(elapsed * 28) * 0.12;
+    } else if (anim === 'defeat') {
+      const k = Math.min(1, elapsed / (DEFEAT_MS / 1000));
+      g.rotation.x = k * (Math.PI / 2);
+      g.position.y = -k * 0.25;
+    }
+  });
+
+  const playProceduralCombatAnimation = useCallback(
+    async (name: 'Attack' | 'Hit' | 'Defeat', callOptions?: PlayAnimationCallOptions) => {
+      if (name === 'Attack') {
+        setAnim('attack');
+        animStartRef.current = performance.now();
+        await new Promise<void>((resolve) => {
+          window.setTimeout(resolve, ATTACK_CONTACT_MS);
+        });
+        window.setTimeout(() => {
+          setAnim('idle');
+          callOptions?.onAnimationComplete?.();
+        }, ATTACK_TOTAL_MS);
+        return;
+      }
+
+      if (name === 'Hit') {
+        setAnim('hit');
+        animStartRef.current = performance.now();
+        await new Promise<void>((resolve) => {
+          window.setTimeout(() => {
+            setAnim('idle');
+            resolve();
+          }, HIT_MS);
+        });
+        return;
+      }
+
+      if (name === 'Defeat') {
+        setAnim('defeat');
+        animStartRef.current = performance.now();
+        await new Promise<void>((resolve) => {
+          window.setTimeout(resolve, DEFEAT_MS);
+        });
+      }
+    },
+    []
+  );
+
+  return { playProceduralCombatAnimation };
+}

--- a/src/hooks/usePlayAnimation.ts
+++ b/src/hooks/usePlayAnimation.ts
@@ -62,7 +62,10 @@ export function usePlayAnimation(
           if (modelId) {
             console.warn(`Animation '${name}' not found for ${modelId}`);
           }
-          return resolve();
+          // useCombatAnimations may run procedural motion; still notify outer wrapper.
+          callOptions?.onAnimationComplete?.();
+          resolve();
+          return;
         }
 
         if (transitionMode === 'stopAll') {

--- a/src/pages/Battle/CombatantModel.tsx
+++ b/src/pages/Battle/CombatantModel.tsx
@@ -146,6 +146,10 @@ export const CombatantModel = forwardRef<CombatantModelHandle, CombatantModelPro
             },
           };
           await (childRef.current?.playAnimation(name, callOptions) ?? Promise.resolve());
+          if (!childRef.current) {
+            startRestore();
+            resolveComplete();
+          }
           return;
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Rahi-placeholder-style procedural combat motion** (root lunge / hit shake / defeat knockdown) for any model that uses `useCombatAnimations` but is missing `Attack`, `Hit`, or `Defeat` clips in the GLB. Timing matches `RahiPlaceholderModel` / `NuiRamaModel` (140ms contact, 420ms full attack, etc.).

Also wires **Nuva models that only had idle** (Gali, Kopaka, Lewa, Onua, Pohatu, Takanuva) through `useCombatAnimations` so they expose `playAnimation` with the same fallback behavior.

Merged latest `master` (includes #272); resolved trivial comment conflicts with that branch in `usePlayAnimation` / `CombatantModel`.

## Technical notes

- **`useModelProceduralCombatMotion`**: `useFrame` applies offsets on the model root group; `playProceduralCombatAnimation` drives state + `setTimeout` pacing.
- **`useCombatAnimations`**: If a combat clip is missing, fades idle (or `stopAll` for Rahkshi), runs procedural motion, then fades GLB idle back in after procedural Attack (via wrapped `onAnimationComplete`) or after procedural Hit. Defeat leaves the knockdown pose.
- **`usePlayAnimation`**: Invokes `onAnimationComplete` when a clip is missing (pairs with outer `CombatantModel` for `waitForAttackComplete`).
- **`CombatantModel`**: Resolves attack completion when there is no inner model.

## Tests

- `useModelProceduralCombatMotion.spec.tsx` (fake timers + mocked `useFrame`)
- `useCombatAnimations.spec.tsx` (mocked deps, asserts procedural path when actions are null)
- `usePlayAnimation.spec.tsx` (from master)

## Verification

- `yarn lint`
- `yarn test:ci`
- `yarn build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3217350-27fb-4bd7-ac55-e6f5018b6fa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3217350-27fb-4bd7-ac55-e6f5018b6fa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

