### PR TITLE
Battle: sink and fade defeated models, dispose GPU resources

### DIFF
--- a/src/components/CharacterScene/NuiRamaModel.tsx
+++ b/src/components/CharacterScene/NuiRamaModel.tsx
@@ -143,6 +143,7 @@ export const NuiRamaModel = forwardRef<CombatantModelHandle, { variant: NuiRamaV
           await new Promise<void>((resolve) => {
             window.setTimeout(resolve, DEFEAT_MS);
           });
+          options?.onAnimationComplete?.();
         }
       },
     }));

--- a/src/components/CharacterScene/RahiPlaceholderModel.tsx
+++ b/src/components/CharacterScene/RahiPlaceholderModel.tsx
@@ -90,6 +90,7 @@ export const RahiPlaceholderModel = forwardRef<
         await new Promise<void>((resolve) => {
           window.setTimeout(resolve, DEFEAT_MS);
         });
+        options?.onAnimationComplete?.();
       }
     },
   }));

--- a/src/hooks/useCombatAnimations.ts
+++ b/src/hooks/useCombatAnimations.ts
@@ -68,6 +68,9 @@ export function useCombatAnimations(
 
       if (hasClip) {
         await basePlay(name, callOptions);
+        if (name === 'Defeat') {
+          mixer.stopAllAction();
+        }
       } else {
         fadeOutIdleForProcedural();
         await playProceduralCombatAnimation(name as 'Hit' | 'Defeat', callOptions);
@@ -76,17 +79,12 @@ export function useCombatAnimations(
           if (idle) {
             idle.reset().fadeIn(0.2).play();
           }
+        } else if (name === 'Defeat') {
+          mixer.stopAllAction();
         }
       }
     },
-    [
-      actions,
-      basePlay,
-      idleActionName,
-      mixer,
-      playProceduralCombatAnimation,
-      transitionMode,
-    ]
+    [actions, basePlay, idleActionName, mixer, playProceduralCombatAnimation, transitionMode]
   );
 
   return { playAnimation };

--- a/src/hooks/usePlayAnimation.ts
+++ b/src/hooks/usePlayAnimation.ts
@@ -119,7 +119,12 @@ export function usePlayAnimation(
           const onComplete = () => {
             mixer.removeEventListener('finished', onComplete);
             resolve();
-            if (name === 'Defeat') return;
+            if (name === 'Defeat') {
+              // Hold the final defeat pose; do not blend back to idle. Stop the mixer so
+              // skeletal updates do not fight the post-defeat sink on the parent group.
+              mixer.stopAllAction();
+              return;
+            }
             // Must fade out the finished action - otherwise it stays active (clampWhenFinished)
             // and keeps blending its end pose with Idle, causing much less movement on 2nd play
             action.fadeOut(0.2);

--- a/src/pages/Battle/CombatantModel.tsx
+++ b/src/pages/Battle/CombatantModel.tsx
@@ -30,6 +30,16 @@ const ROTATION_RESTORE_DURATION = 0.25;
 const DEFEAT_SINK_DURATION_SEC = 1.35;
 const DEFEAT_SINK_DEPTH = 0.55;
 
+/** `useGLTF` template meshes (Toa, etc.) must not dispose shared geometry; clones (enemies) may. */
+function canDisposeBattleModelGeometry(model: string): boolean {
+  return (
+    model === 'bohrok' ||
+    model === 'rahkshi' ||
+    model === 'rahi_placeholder' ||
+    model === 'nui_rama'
+  );
+}
+
 /** World-space Y offset for the floating HP bar, tuned per model family. */
 function hpBarYOffset(model: string): number {
   switch (model) {
@@ -142,7 +152,9 @@ export const CombatantModel = forwardRef<CombatantModelHandle, CombatantModelPro
         mat.dispose();
       }
       defeatFadeMaterialsRef.current = [];
-      disposeObject3DResources(g);
+      if (canDisposeBattleModelGeometry(combatant.model)) {
+        disposeObject3DResources(g);
+      }
       setModelDisposed(true);
       const done = sink.onDone;
       sink.onDone = null;

--- a/src/pages/Battle/CombatantModel.tsx
+++ b/src/pages/Battle/CombatantModel.tsx
@@ -248,7 +248,8 @@ export const CombatantModel = forwardRef<CombatantModelHandle, CombatantModelPro
               startRestore();
             }
           }
-          await runDefeatSinkAndDispose();
+          // Sink/fade runs on the render loop; do not block combat awaiting it.
+          void runDefeatSinkAndDispose();
           return;
         }
 

--- a/src/pages/Battle/CombatantModel.tsx
+++ b/src/pages/Battle/CombatantModel.tsx
@@ -17,7 +17,8 @@ import { OnuaNuvaModel } from '../../components/CharacterScene/Nuva/OnuaNuvaMode
 import { PohatuNuvaModel } from '../../components/CharacterScene/Nuva/PohatuNuvaModel';
 import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { Group } from 'three';
+import { Group, Material, Mesh } from 'three';
+import { disposeObject3DResources } from '../../utils/disposeThreeObject';
 import { KraataPower } from '../../types/Kraata';
 import { TakanuvaModel } from '../../components/CharacterScene/Nuva/TakanuvaModel';
 import { RahiPlaceholderModel } from '../../components/CharacterScene/RahiPlaceholderModel';
@@ -25,6 +26,9 @@ import { NuiRamaModel } from '../../components/CharacterScene/NuiRamaModel';
 import { WorldSpaceHpBar } from './WorldSpaceHpBar';
 
 const ROTATION_RESTORE_DURATION = 0.25;
+/** After Defeat clip / procedural knockdown, sink into ground and fade out. */
+const DEFEAT_SINK_DURATION_SEC = 1.35;
+const DEFEAT_SINK_DEPTH = 0.55;
 
 /** World-space Y offset for the floating HP bar, tuned per model family. */
 function hpBarYOffset(model: string): number {
@@ -92,17 +96,57 @@ export const CombatantModel = forwardRef<CombatantModelHandle, CombatantModelPro
     const baseRotationY = side === 'team' ? Math.PI : 0;
     const [overrideRotationY, setOverrideRotationY] = useState<number | null>(null);
     const restoreRef = useRef<{ from: number; startTimeMs: number } | null>(null);
+    const [modelDisposed, setModelDisposed] = useState(false);
+
+    const defeatSinkRef = useRef<{
+      active: boolean;
+      startMs: number;
+      onDone: (() => void) | null;
+    }>({ active: false, startMs: 0, onDone: null });
+    const defeatFadeMaterialsRef = useRef<Material[]>([]);
 
     useFrame(() => {
       const restore = restoreRef.current;
-      if (!restore) return;
-      const elapsedSec = (performance.now() - restore.startTimeMs) / 1000;
-      const t = Math.min(1, elapsedSec / ROTATION_RESTORE_DURATION);
-      setOverrideRotationY(lerpAngle(restore.from, baseRotationY, t));
-      if (t >= 1) {
-        restoreRef.current = null;
-        setOverrideRotationY(null);
+      if (restore) {
+        const elapsedSec = (performance.now() - restore.startTimeMs) / 1000;
+        const t = Math.min(1, elapsedSec / ROTATION_RESTORE_DURATION);
+        setOverrideRotationY(lerpAngle(restore.from, baseRotationY, t));
+        if (t >= 1) {
+          restoreRef.current = null;
+          setOverrideRotationY(null);
+        }
       }
+
+      const sink = defeatSinkRef.current;
+      if (!sink.active) return;
+      const g = modelGroup.current;
+      if (!g) {
+        sink.active = false;
+        sink.onDone?.();
+        sink.onDone = null;
+        return;
+      }
+
+      const elapsedSec = (performance.now() - sink.startMs) / 1000;
+      const t = Math.min(1, elapsedSec / DEFEAT_SINK_DURATION_SEC);
+      g.position.y = -t * DEFEAT_SINK_DEPTH;
+      const fade = 1 - t;
+      for (const mat of defeatFadeMaterialsRef.current) {
+        const base = (mat.userData.defeatBaseOpacity as number | undefined) ?? 1;
+        mat.opacity = base * fade;
+      }
+      if (t < 1) return;
+
+      sink.active = false;
+      for (const mat of defeatFadeMaterialsRef.current) {
+        mat.dispose();
+      }
+      defeatFadeMaterialsRef.current = [];
+      disposeObject3DResources(g);
+      setModelDisposed(true);
+      const done = sink.onDone;
+      sink.onDone = null;
+      done?.();
     });
 
     const rotationY = overrideRotationY ?? baseRotationY;
@@ -134,6 +178,36 @@ export const CombatantModel = forwardRef<CombatantModelHandle, CombatantModelPro
           }
         };
 
+        const runDefeatSinkAndDispose = () =>
+          new Promise<void>((resolve) => {
+            const g = modelGroup.current;
+            if (!g || !childRef.current) {
+              resolve();
+              return;
+            }
+            g.position.set(0, 0, 0);
+            defeatFadeMaterialsRef.current = [];
+            g.traverse((obj) => {
+              if (!(obj instanceof Mesh)) return;
+              const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+              const clones = mats.map((mat) => {
+                const c = mat.clone();
+                c.transparent = true;
+                c.opacity = mat.opacity;
+                c.needsUpdate = true;
+                c.userData.defeatBaseOpacity = mat.opacity;
+                defeatFadeMaterialsRef.current.push(c);
+                return c;
+              });
+              obj.material = Array.isArray(obj.material) ? clones : clones[0]!;
+            });
+            defeatSinkRef.current = {
+              active: true,
+              startMs: performance.now(),
+              onDone: resolve,
+            };
+          });
+
         if (name === 'Attack') {
           let resolveComplete!: () => void;
           attackCompleteRef.current = new Promise<void>((r) => {
@@ -151,6 +225,18 @@ export const CombatantModel = forwardRef<CombatantModelHandle, CombatantModelPro
             startRestore();
             resolveComplete();
           }
+          return;
+        }
+
+        if (name === 'Defeat') {
+          try {
+            await (childRef.current?.playAnimation(name, options) ?? Promise.resolve());
+          } finally {
+            if (faceTargetId && facingY !== null) {
+              startRestore();
+            }
+          }
+          await runDefeatSinkAndDispose();
           return;
         }
 
@@ -394,15 +480,15 @@ export const CombatantModel = forwardRef<CombatantModelHandle, CombatantModelPro
     })();
     return (
       <group position={position}>
-        <WorldSpaceHpBar
-          name={combatant.name}
-          hp={combatant.hp}
-          maxHp={combatant.maxHp}
-          yOffset={hpBarYOffset(combatant.model)}
-          popupDirection={side === 'team' ? 'down' : 'up'}
-        />
         <group ref={modelGroup} rotation={rotation}>
-          {model}
+          <WorldSpaceHpBar
+            name={combatant.name}
+            hp={combatant.hp}
+            maxHp={combatant.maxHp}
+            yOffset={hpBarYOffset(combatant.model)}
+            popupDirection={side === 'team' ? 'down' : 'up'}
+          />
+          {!modelDisposed && model}
         </group>
       </group>
     );

--- a/src/utils/disposeThreeObject.ts
+++ b/src/utils/disposeThreeObject.ts
@@ -1,0 +1,36 @@
+import type { Material, Object3D } from 'three';
+import { Mesh } from 'three';
+
+export type DisposeObject3DOptions = {
+  /**
+   * When false (default), only mesh geometries are disposed. Many battle meshes share
+   * materials from caches or GLTF templates; disposing those would break other instances.
+   */
+  disposeMaterials?: boolean;
+};
+
+/**
+ * Frees GPU memory under `root`. Default: geometry only (safe for shared materials).
+ * Use for GLB clones that are not auto-disposed by R3F `<primitive>`.
+ */
+export function disposeObject3DResources(root: Object3D, options?: DisposeObject3DOptions): void {
+  const disposeMaterials = options?.disposeMaterials ?? false;
+  root.traverse((obj) => {
+    if (!(obj as Mesh).isMesh) return;
+    const mesh = obj as Mesh;
+    mesh.geometry?.dispose();
+
+    if (!disposeMaterials) return;
+
+    const mat = mesh.material;
+    if (Array.isArray(mat)) {
+      mat.forEach(disposeMaterial);
+    } else if (mat) {
+      disposeMaterial(mat);
+    }
+  });
+}
+
+function disposeMaterial(material: Material): void {
+  material.dispose?.();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a combatant plays **Defeat** (GLB clip or procedural), the outer `CombatantModel` runs a follow-up: the whole model group (including the world-space HP bar) **sinks into the ground** while **opacity fades to zero**. At the end, **cloned fade materials are disposed**. **Mesh geometries** under that group are disposed only for **cloned** enemy models (Bohrok, Rahkshi, Nui-Rama, Rahi placeholder); Toa use shared GLTF nodes so geometry is not disposed there.

**Combat flow:** `playAnimation('Defeat')` resolves after the defeat **clip or procedural** phase only. The sink/fade runs on `useFrame` via `void runDefeatSinkAndDispose()` so it does **not** block the next combat step.

## Technical notes

- `usePlayAnimation` / `useCombatAnimations`: after clip Defeat, `mixer.stopAllAction()` holds the final pose.
- `NuiRamaModel` / `RahiPlaceholderModel`: `onAnimationComplete` after procedural Defeat.

## Testing

- `yarn lint`
- `yarn test:ci`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-063b6890-47c7-414f-9168-58ada49eca46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-063b6890-47c7-414f-9168-58ada49eca46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

