### PR TITLE
Battle: hold Defeat clip final frame during sink/dispose

### DIFF
--- a/src/hooks/useCombatAnimations.ts
+++ b/src/hooks/useCombatAnimations.ts
@@ -68,9 +68,6 @@ export function useCombatAnimations(
 
       if (hasClip) {
         await basePlay(name, callOptions);
-        if (name === 'Defeat') {
-          mixer.stopAllAction();
-        }
       } else {
         fadeOutIdleForProcedural();
         await playProceduralCombatAnimation(name as 'Hit' | 'Defeat', callOptions);
@@ -79,8 +76,6 @@ export function useCombatAnimations(
           if (idle) {
             idle.reset().fadeIn(0.2).play();
           }
-        } else if (name === 'Defeat') {
-          mixer.stopAllAction();
         }
       }
     },

--- a/src/hooks/usePlayAnimation.ts
+++ b/src/hooks/usePlayAnimation.ts
@@ -120,9 +120,10 @@ export function usePlayAnimation(
             mixer.removeEventListener('finished', onComplete);
             resolve();
             if (name === 'Defeat') {
-              // Hold the final defeat pose; do not blend back to idle. Stop the mixer so
-              // skeletal updates do not fight the post-defeat sink on the parent group.
-              mixer.stopAllAction();
+              // Hold the final frame: fade out idle only. Do not stopAllAction — that zeros
+              // weights and snaps the skeleton to bind pose before the sink phase.
+              actions[idleActionName]?.fadeOut(0);
+              actions[idleActionName]?.stop();
               return;
             }
             // Must fade out the finished action - otherwise it stays active (clampWhenFinished)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After merging the defeat sink/fade, clip-based rigs **snapped to bind pose** when the sink started. That happened because `mixer.stopAllAction()` ran after Defeat finished, which **zeros all action weights** instead of freezing the skeleton in the defeat pose.

## Change

- **`usePlayAnimation`**: On Defeat completion, **fade out and stop idle only** (weight 0), leave the **Defeat** action active at its final time so the mixer keeps the last frame.
- **`useCombatAnimations`**: Removed redundant `mixer.stopAllAction()` after Defeat (clip and procedural paths). Procedural Defeat already used `fadeOutIdleForProcedural`; clip Defeat is now handled entirely in `usePlayAnimation`.

## Testing

- `yarn lint`
- `yarn test:ci`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-063b6890-47c7-414f-9168-58ada49eca46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-063b6890-47c7-414f-9168-58ada49eca46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

