### PR TITLE
Delay battle rewards panel until defeat animations and camera finish

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -14,6 +14,7 @@ const shouldShowCurrencyBar = (pathname: string) => {
 
 export const NavBar = ({ isPortrait }: { isPortrait: boolean }) => {
   const { battle, completedQuests, collectedKrana } = useGame();
+  const { outcomePresentationReady } = battle;
   const { pathname } = useLocation();
   const hasVisibleEncounters = useMemo(
     () => getVisibleEncounters(ENCOUNTERS, collectedKrana, completedQuests).length > 0,
@@ -26,8 +27,8 @@ export const NavBar = ({ isPortrait }: { isPortrait: boolean }) => {
         battle.currentEncounter &&
         !(
           battle.phase === BattlePhase.Retreated ||
-          battle.phase === BattlePhase.Defeat ||
-          battle.phase === BattlePhase.Victory
+          (battle.phase === BattlePhase.Defeat && outcomePresentationReady) ||
+          (battle.phase === BattlePhase.Victory && outcomePresentationReady)
         )
           ? 'hidden'
           : ''

--- a/src/game/battleOutcomeVisualDelay.spec.ts
+++ b/src/game/battleOutcomeVisualDelay.spec.ts
@@ -1,0 +1,11 @@
+import { getBattleOutcomePhaseDelayMs } from './battleOutcomeVisualDelay';
+
+describe('getBattleOutcomePhaseDelayMs', () => {
+  it('returns 0 when reduced motion is preferred', () => {
+    expect(getBattleOutcomePhaseDelayMs(true)).toBe(0);
+  });
+
+  it('returns a positive delay when animations run', () => {
+    expect(getBattleOutcomePhaseDelayMs(false)).toBeGreaterThan(1000);
+  });
+});

--- a/src/game/battleOutcomeVisualDelay.ts
+++ b/src/game/battleOutcomeVisualDelay.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared timing so battle phase (nav + outcome UI) waits for procedural defeat
+ * sink/fade and the final camera zoom-out after the last attack emphasis.
+ */
+
+export const DEFEAT_SINK_DURATION_SEC = 1.35;
+
+const CAMERA_EMPHASIS_HOLD_MS = 150;
+const CAMERA_EMPHASIS_OUT_MS = 380;
+
+export { CAMERA_EMPHASIS_HOLD_MS, CAMERA_EMPHASIS_OUT_MS };
+
+const OUTCOME_VISUAL_CUSHION_SEC = 0.12;
+
+/** Delay before exposing Victory/Defeat phase to UI (ms). */
+export function getBattleOutcomePhaseDelayMs(prefersReducedMotion: boolean): number {
+  if (prefersReducedMotion) return 0;
+  return Math.round(
+    (DEFEAT_SINK_DURATION_SEC +
+      (CAMERA_EMPHASIS_HOLD_MS + CAMERA_EMPHASIS_OUT_MS) / 1000 +
+      OUTCOME_VISUAL_CUSHION_SEC) *
+      1000
+  );
+}

--- a/src/hooks/useBattleState.tsx
+++ b/src/hooks/useBattleState.tsx
@@ -109,6 +109,16 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
   /** Average party level when the current encounter uses `scalesWithParty`. */
   const partyAvgLevelRef = useRef<number | null>(null);
   const pendingPresentationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /**
+   * Incremented when combat playback must stop (Victory/Defeat, new round, battle reset).
+   * `playActionQueue` bails if its captured token no longer matches, avoiding overlapping
+   * rounds and duplicate `playActionQueue` calls when `isRunningRound` flips before the queue drains.
+   */
+  const combatPlaybackTokenRef = useRef(0);
+
+  const bumpCombatPlaybackToken = () => {
+    combatPlaybackTokenRef.current += 1;
+  };
 
   const clearPendingPresentation = () => {
     if (pendingPresentationTimerRef.current !== null) {
@@ -133,6 +143,8 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
     // Team wipe takes precedence (same ordering as separate effects would race).
     if (allTeamDefeated) {
       console.log('Defeat!');
+      bumpCombatPlaybackToken();
+      setActionQueue([]);
       setIsRunningRound(false);
       setPhase(BattlePhase.Defeat);
       return;
@@ -140,6 +152,8 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
 
     if (allEnemiesDefeated) {
       console.log('Victory!');
+      bumpCombatPlaybackToken();
+      setActionQueue([]);
       setIsRunningRound(false);
       setPhase(BattlePhase.Victory);
     }
@@ -166,6 +180,8 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
 
   const startBattle = (encounter: EnemyEncounter) => {
     clearPendingPresentation();
+    bumpCombatPlaybackToken();
+    setActionQueue([]);
     setCurrentEncounter(encounter);
     setTeam([]);
     setEnemies(
@@ -186,6 +202,8 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
 
   const advanceWave = () => {
     if (!currentEncounter) return;
+    bumpCombatPlaybackToken();
+    setActionQueue([]);
     const nextWave = currentWave + 1;
     setCurrentWave(nextWave);
 
@@ -208,6 +226,8 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
 
   const retreat = () => {
     clearPendingPresentation();
+    bumpCombatPlaybackToken();
+    setActionQueue([]);
     if (phase === BattlePhase.Preparing) {
       setPhase(BattlePhase.Idle);
       setCurrentEncounter(undefined);
@@ -219,6 +239,8 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
 
   const endBattle = () => {
     clearPendingPresentation();
+    bumpCombatPlaybackToken();
+    setActionQueue([]);
     setPhase(BattlePhase.Idle);
     setCurrentEncounter(undefined);
     setCurrentWave(0);
@@ -260,10 +282,13 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
         )
       )
     );
+    bumpCombatPlaybackToken();
+    setActionQueue([]);
     setPhase(BattlePhase.Inprogress);
   };
 
   const runRound = () => {
+    bumpCombatPlaybackToken();
     const queue: (() => void)[] = [];
     const setTeamWithRef = (t: Combatant[]) => {
       teamRef.current = t;
@@ -289,13 +314,26 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
   };
 
   const playActionQueue = async () => {
+    const playbackToken = combatPlaybackTokenRef.current;
     setIsRunningRound(true);
 
     let queue = [...actionQueue];
 
+    const isAborted = () => combatPlaybackTokenRef.current !== playbackToken;
+
     while (queue.length > 0) {
+      if (isAborted()) {
+        // Do not clear actionQueue here — a newer runRound may have set it.
+        setIsRunningRound(false);
+        return;
+      }
+
       for (const step of queue) {
         await step();
+        if (isAborted()) {
+          setIsRunningRound(false);
+          return;
+        }
       }
 
       const latestTeam = teamRef.current;
@@ -322,6 +360,11 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
         (fn) => queue.push(fn),
         () => ({ team: teamRef.current, enemies: enemiesRef.current })
       );
+    }
+
+    if (isAborted()) {
+      setIsRunningRound(false);
+      return;
     }
 
     setActionQueue([]);

--- a/src/hooks/useBattleState.tsx
+++ b/src/hooks/useBattleState.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useReducedMotion } from 'motion/react';
 import { Combatant, EnemyEncounter } from '../types/Combat';
 import { RecruitedCharacterData } from '../types/Matoran';
 import { getLevelFromExp } from '../game/Levelling';
@@ -9,6 +10,7 @@ import {
   decrementWaveCounters,
   hasReadyMaskPowers,
 } from '../services/combatUtils';
+import { getBattleOutcomePhaseDelayMs } from '../game/battleOutcomeVisualDelay';
 
 export const enum BattlePhase {
   Idle = 'idle',
@@ -84,6 +86,7 @@ const TOA_NUVA_IDS = [
 ] as const;
 
 export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
+  const reduceMotion = useReducedMotion() ?? false;
   const [phase, setPhase] = useState<BattlePhase>(INITIAL_BATTLE_STATE.phase);
   const [currentEncounter, setCurrentEncounter] = useState<EnemyEncounter | undefined>(
     INITIAL_BATTLE_STATE.currentEncounter
@@ -97,32 +100,63 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
   const enemiesRef = useRef(enemies);
   /** Average party level when the current encounter uses `scalesWithParty`. */
   const partyAvgLevelRef = useRef<number | null>(null);
+  /** Cleared on retreat/endBattle/startBattle; avoids overlapping delayed outcome phases. */
+  const pendingOutcomePhaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearPendingOutcomePhase = () => {
+    if (pendingOutcomePhaseTimerRef.current !== null) {
+      clearTimeout(pendingOutcomePhaseTimerRef.current);
+      pendingOutcomePhaseTimerRef.current = null;
+    }
+  };
+
   teamRef.current = team;
   enemiesRef.current = enemies;
 
   useEffect(() => {
-    const allTeamDefeated = team.length && team.every((t) => t.hp <= 0);
+    if (phase !== BattlePhase.Inprogress) return;
+
+    const allTeamDefeated = team.length > 0 && team.every((t) => t.hp <= 0);
+    const allEnemiesDefeated =
+      !!currentEncounter &&
+      currentWave === currentEncounter.waves.length - 1 &&
+      enemies.length > 0 &&
+      enemies.every((e) => e.hp <= 0);
+
+    // Team wipe takes precedence (same ordering as separate effects would race).
     if (allTeamDefeated) {
       console.log('Defeat!');
       setIsRunningRound(false);
-      setPhase(BattlePhase.Defeat);
+      const delayMs = getBattleOutcomePhaseDelayMs(reduceMotion);
+      if (delayMs === 0) {
+        setPhase(BattlePhase.Defeat);
+        return;
+      }
+      pendingOutcomePhaseTimerRef.current = setTimeout(() => {
+        pendingOutcomePhaseTimerRef.current = null;
+        setPhase(BattlePhase.Defeat);
+      }, delayMs);
+      return clearPendingOutcomePhase;
     }
-  }, [team]);
 
-  useEffect(() => {
-    const allEnemiesDefeated =
-      currentEncounter &&
-      currentWave === currentEncounter.waves.length - 1 &&
-      enemies.length &&
-      enemies.every((e) => e.hp <= 0);
     if (allEnemiesDefeated) {
       console.log('Victory!');
       setIsRunningRound(false);
-      setPhase(BattlePhase.Victory);
+      const delayMs = getBattleOutcomePhaseDelayMs(reduceMotion);
+      if (delayMs === 0) {
+        setPhase(BattlePhase.Victory);
+        return;
+      }
+      pendingOutcomePhaseTimerRef.current = setTimeout(() => {
+        pendingOutcomePhaseTimerRef.current = null;
+        setPhase(BattlePhase.Victory);
+      }, delayMs);
+      return clearPendingOutcomePhase;
     }
-  }, [currentEncounter, currentWave, enemies]);
+  }, [currentEncounter, currentWave, enemies, team, phase, reduceMotion]);
 
   const startBattle = (encounter: EnemyEncounter) => {
+    clearPendingOutcomePhase();
     setCurrentEncounter(encounter);
     setTeam([]);
     setEnemies(
@@ -164,6 +198,7 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
   };
 
   const retreat = () => {
+    clearPendingOutcomePhase();
     if (phase === BattlePhase.Preparing) {
       setPhase(BattlePhase.Idle);
       setCurrentEncounter(undefined);
@@ -174,6 +209,7 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
   };
 
   const endBattle = () => {
+    clearPendingOutcomePhase();
     setPhase(BattlePhase.Idle);
     setCurrentEncounter(undefined);
     setCurrentWave(0);

--- a/src/hooks/useBattleState.tsx
+++ b/src/hooks/useBattleState.tsx
@@ -23,6 +23,12 @@ export const enum BattlePhase {
 
 export interface BattleState {
   phase: BattlePhase;
+  /**
+   * After functional Victory/Defeat, stays false until defeat sink + camera framing
+   * have had time to finish; then true so nav and outcome UI appear together.
+   * Always true when not in Victory/Defeat.
+   */
+  outcomePresentationReady: boolean;
   currentEncounter: EnemyEncounter | undefined;
   currentWave: number;
   enemies: Combatant[];
@@ -41,6 +47,7 @@ export interface BattleState {
 
 export const INITIAL_BATTLE_STATE: BattleState = {
   phase: BattlePhase.Idle,
+  outcomePresentationReady: true,
   currentWave: 0,
   currentEncounter: undefined,
   enemies: [],
@@ -96,17 +103,17 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
   const [team, setTeam] = useState<Combatant[]>(INITIAL_BATTLE_STATE.team);
   const [actionQueue, setActionQueue] = useState<(() => void)[]>([]);
   const [isRunningRound, setIsRunningRound] = useState(false);
+  const [outcomePresentationReady, setOutcomePresentationReady] = useState(true);
   const teamRef = useRef(team);
   const enemiesRef = useRef(enemies);
   /** Average party level when the current encounter uses `scalesWithParty`. */
   const partyAvgLevelRef = useRef<number | null>(null);
-  /** Cleared on retreat/endBattle/startBattle; avoids overlapping delayed outcome phases. */
-  const pendingOutcomePhaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingPresentationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const clearPendingOutcomePhase = () => {
-    if (pendingOutcomePhaseTimerRef.current !== null) {
-      clearTimeout(pendingOutcomePhaseTimerRef.current);
-      pendingOutcomePhaseTimerRef.current = null;
+  const clearPendingPresentation = () => {
+    if (pendingPresentationTimerRef.current !== null) {
+      clearTimeout(pendingPresentationTimerRef.current);
+      pendingPresentationTimerRef.current = null;
     }
   };
 
@@ -127,36 +134,38 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
     if (allTeamDefeated) {
       console.log('Defeat!');
       setIsRunningRound(false);
-      const delayMs = getBattleOutcomePhaseDelayMs(reduceMotion);
-      if (delayMs === 0) {
-        setPhase(BattlePhase.Defeat);
-        return;
-      }
-      pendingOutcomePhaseTimerRef.current = setTimeout(() => {
-        pendingOutcomePhaseTimerRef.current = null;
-        setPhase(BattlePhase.Defeat);
-      }, delayMs);
-      return clearPendingOutcomePhase;
+      setPhase(BattlePhase.Defeat);
+      return;
     }
 
     if (allEnemiesDefeated) {
       console.log('Victory!');
       setIsRunningRound(false);
-      const delayMs = getBattleOutcomePhaseDelayMs(reduceMotion);
-      if (delayMs === 0) {
-        setPhase(BattlePhase.Victory);
-        return;
-      }
-      pendingOutcomePhaseTimerRef.current = setTimeout(() => {
-        pendingOutcomePhaseTimerRef.current = null;
-        setPhase(BattlePhase.Victory);
-      }, delayMs);
-      return clearPendingOutcomePhase;
+      setPhase(BattlePhase.Victory);
     }
-  }, [currentEncounter, currentWave, enemies, team, phase, reduceMotion]);
+  }, [currentEncounter, currentWave, enemies, team, phase]);
+
+  useEffect(() => {
+    clearPendingPresentation();
+    if (phase !== BattlePhase.Victory && phase !== BattlePhase.Defeat) {
+      setOutcomePresentationReady(true);
+      return;
+    }
+    const delayMs = getBattleOutcomePhaseDelayMs(reduceMotion);
+    if (delayMs === 0) {
+      setOutcomePresentationReady(true);
+      return;
+    }
+    setOutcomePresentationReady(false);
+    pendingPresentationTimerRef.current = setTimeout(() => {
+      pendingPresentationTimerRef.current = null;
+      setOutcomePresentationReady(true);
+    }, delayMs);
+    return clearPendingPresentation;
+  }, [phase, reduceMotion]);
 
   const startBattle = (encounter: EnemyEncounter) => {
-    clearPendingOutcomePhase();
+    clearPendingPresentation();
     setCurrentEncounter(encounter);
     setTeam([]);
     setEnemies(
@@ -198,7 +207,7 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
   };
 
   const retreat = () => {
-    clearPendingOutcomePhase();
+    clearPendingPresentation();
     if (phase === BattlePhase.Preparing) {
       setPhase(BattlePhase.Idle);
       setCurrentEncounter(undefined);
@@ -209,7 +218,7 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
   };
 
   const endBattle = () => {
-    clearPendingOutcomePhase();
+    clearPendingPresentation();
     setPhase(BattlePhase.Idle);
     setCurrentEncounter(undefined);
     setCurrentWave(0);
@@ -321,6 +330,7 @@ export const useBattleState = (nuvaSymbolsSequestered = false): BattleState => {
 
   return {
     phase,
+    outcomePresentationReady,
     currentEncounter,
     currentWave,
     enemies,

--- a/src/pages/Battle/Arena.tsx
+++ b/src/pages/Battle/Arena.tsx
@@ -9,6 +9,10 @@ import { useSettings } from '../../context/useSettings';
 import { shouldEnableShadows } from '../../utils/testMode';
 import { HitImpactParticles } from './HitImpactParticles';
 import { subscribeBattleCameraEmphasis } from '../../utils/battleCameraEmphasis';
+import {
+  CAMERA_EMPHASIS_HOLD_MS,
+  CAMERA_EMPHASIS_OUT_MS,
+} from '../../game/battleOutcomeVisualDelay';
 
 function EnvironmentIntensity({ value }: { value: number }) {
   const scene = useThree((s) => s.scene);
@@ -43,10 +47,6 @@ const ARENA_MARGIN = 1;
 /** Arena center (camera looks at this). */
 const ARENA_CENTER: [number, number, number] = [0, 0, 0];
 const CAMERA_EMPHASIS_IN_MS = 320;
-/** Exported for battle outcome UI timing (zoom-out after final action). */
-export const CAMERA_EMPHASIS_OUT_MS = 380;
-/** Exported for battle outcome UI timing (hold before zoom-out). */
-export const CAMERA_EMPHASIS_HOLD_MS = 150;
 const CAMERA_EMPHASIS_RETARGET_MS = 240;
 const CAMERA_EMPHASIS_ZOOM_MULT = 1.05;
 /** Shoulder offset — camera sits behind and above the Toa, looking past them at the enemy. */

--- a/src/pages/Battle/Arena.tsx
+++ b/src/pages/Battle/Arena.tsx
@@ -43,8 +43,10 @@ const ARENA_MARGIN = 1;
 /** Arena center (camera looks at this). */
 const ARENA_CENTER: [number, number, number] = [0, 0, 0];
 const CAMERA_EMPHASIS_IN_MS = 320;
-const CAMERA_EMPHASIS_OUT_MS = 380;
-const CAMERA_EMPHASIS_HOLD_MS = 150;
+/** Exported for battle outcome UI timing (zoom-out after final action). */
+export const CAMERA_EMPHASIS_OUT_MS = 380;
+/** Exported for battle outcome UI timing (hold before zoom-out). */
+export const CAMERA_EMPHASIS_HOLD_MS = 150;
 const CAMERA_EMPHASIS_RETARGET_MS = 240;
 const CAMERA_EMPHASIS_ZOOM_MULT = 1.05;
 /** Shoulder offset — camera sits behind and above the Toa, looking past them at the enemy. */

--- a/src/pages/Battle/BattleOutcome.tsx
+++ b/src/pages/Battle/BattleOutcome.tsx
@@ -34,8 +34,6 @@ interface BattleOutcomeProps {
   kranaRewards: KranaReward[];
   kraataRewards: KraataReward[];
   onCollect: () => void;
-  /** When false (Victory/Defeat only), hide UI until arena defeat/camera animations finish. */
-  showContent?: boolean;
 }
 
 function OutcomeTitle({ phase }: { phase: BattlePhase }) {
@@ -361,7 +359,6 @@ export function BattleOutcome({
   kranaRewards,
   kraataRewards,
   onCollect,
-  showContent = true,
 }: BattleOutcomeProps) {
   const shouldReduceMotion = (useReducedMotion() ?? false) || isTestMode();
 
@@ -389,10 +386,6 @@ export function BattleOutcome({
       ),
     [shouldReduceMotion, hasLoot, lootDelay]
   );
-
-  if (!showContent) {
-    return null;
-  }
 
   return (
     <>

--- a/src/pages/Battle/BattleOutcome.tsx
+++ b/src/pages/Battle/BattleOutcome.tsx
@@ -34,6 +34,8 @@ interface BattleOutcomeProps {
   kranaRewards: KranaReward[];
   kraataRewards: KraataReward[];
   onCollect: () => void;
+  /** When false (Victory/Defeat only), hide UI until arena defeat/camera animations finish. */
+  showContent?: boolean;
 }
 
 function OutcomeTitle({ phase }: { phase: BattlePhase }) {
@@ -359,6 +361,7 @@ export function BattleOutcome({
   kranaRewards,
   kraataRewards,
   onCollect,
+  showContent = true,
 }: BattleOutcomeProps) {
   const shouldReduceMotion = (useReducedMotion() ?? false) || isTestMode();
 
@@ -386,6 +389,10 @@ export function BattleOutcome({
       ),
     [shouldReduceMotion, hasLoot, lootDelay]
   );
+
+  if (!showContent) {
+    return null;
+  }
 
   return (
     <>

--- a/src/pages/Battle/CombatantModel.tsx
+++ b/src/pages/Battle/CombatantModel.tsx
@@ -27,7 +27,7 @@ import { WorldSpaceHpBar } from './WorldSpaceHpBar';
 
 const ROTATION_RESTORE_DURATION = 0.25;
 /** After Defeat clip / procedural knockdown, sink into ground and fade out. */
-const DEFEAT_SINK_DURATION_SEC = 1.35;
+export const DEFEAT_SINK_DURATION_SEC = 1.35;
 const DEFEAT_SINK_DEPTH = 0.55;
 
 /** `useGLTF` template meshes (Toa, etc.) must not dispose shared geometry; clones (enemies) may. */

--- a/src/pages/Battle/CombatantModel.tsx
+++ b/src/pages/Battle/CombatantModel.tsx
@@ -24,10 +24,9 @@ import { TakanuvaModel } from '../../components/CharacterScene/Nuva/TakanuvaMode
 import { RahiPlaceholderModel } from '../../components/CharacterScene/RahiPlaceholderModel';
 import { NuiRamaModel } from '../../components/CharacterScene/NuiRamaModel';
 import { WorldSpaceHpBar } from './WorldSpaceHpBar';
+import { DEFEAT_SINK_DURATION_SEC } from '../../game/battleOutcomeVisualDelay';
 
 const ROTATION_RESTORE_DURATION = 0.25;
-/** After Defeat clip / procedural knockdown, sink into ground and fade out. */
-export const DEFEAT_SINK_DURATION_SEC = 1.35;
 const DEFEAT_SINK_DEPTH = 0.55;
 
 /** `useGLTF` template meshes (Toa, etc.) must not dispose shared geometry; clones (enemies) may. */

--- a/src/pages/Battle/InProgress.tsx
+++ b/src/pages/Battle/InProgress.tsx
@@ -1,13 +1,22 @@
-import { useReducedMotion } from 'motion/react';
+import { motion, useReducedMotion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 import { useGame } from '../../context/Game';
 import { isTestMode } from '../../utils/testMode';
 import { AllyCard } from './Cards/Ally';
+import { buildTransition, MOTION_DURATION, MOTION_EASING } from '../../motion/transitions';
 
 /** Total fade in + fade out; keep in sync with `battle-arena-wave-clear` duration in `battle.scss`. */
 const WAVE_CLEAR_TOTAL_MS = 1000;
 
-export const BattleInProgress = () => {
+export interface BattleInProgressProps {
+  /**
+   * When true (Victory/Defeat while outcome UI is deferred), fade out the wave header,
+   * ally cards, and buttons instead of unmounting them instantly.
+   */
+  exitPresentation?: boolean;
+}
+
+export const BattleInProgress = ({ exitPresentation = false }: BattleInProgressProps) => {
   const { battle } = useGame();
   const { currentWave, enemies, team, actionQueue, playActionQueue, isRunningRound, retreat } =
     battle;
@@ -47,53 +56,70 @@ export const BattleInProgress = () => {
     );
   };
 
-  const buttonsLocked = isRunningRound || waveClearPlaying;
+  const buttonsLocked = isRunningRound || waveClearPlaying || exitPresentation;
+
+  const exitTransition = buildTransition(
+    {
+      duration: MOTION_DURATION.slow,
+      ease: MOTION_EASING.standard,
+      delay: 0.18,
+    },
+    shouldReduceMotion
+  );
 
   return (
     <div className="page-container battle">
-      <h1 className="title">Wave {currentWave + 1}</h1>
+      <motion.div
+        className="battle-in-progress__chrome"
+        initial={{ opacity: 1, y: 0 }}
+        animate={
+          exitPresentation ? { opacity: 0, y: 10 } : { opacity: 1, y: 0 }
+        }
+        transition={exitTransition}
+        style={{ pointerEvents: exitPresentation ? 'none' : undefined }}
+      >
+        <h1 className="title">Wave {currentWave + 1}</h1>
 
-      <div className={`battle-arena${waveClearPlaying ? ' battle-arena--wave-clear' : ''}`}>
-        {/* Enemy Side */}
-        <div className="enemy-side"></div>
+        <div className={`battle-arena${waveClearPlaying ? ' battle-arena--wave-clear' : ''}`}>
+          <div className="enemy-side"></div>
 
-        {/* Ally Side */}
-        <div className="ally-side">
-          <div className="toa-team">
-            {team.map((toa, i) => (
-              <AllyCard
-                key={i}
-                combatant={toa}
-                onClick={() => battle.toggleAbility(toa)}
-                team={team}
-                enemies={enemies}
-              />
-            ))}
+          <div className="ally-side">
+            <div className="toa-team">
+              {team.map((toa, i) => (
+                <AllyCard
+                  key={i}
+                  combatant={toa}
+                  onClick={() => battle.toggleAbility(toa)}
+                  team={team}
+                  enemies={enemies}
+                />
+              ))}
+            </div>
           </div>
         </div>
-      </div>
 
-      <div className="battle-buttons">
-        <button className="cancel-button" disabled={buttonsLocked} onClick={() => retreat()}>
-          Retreat
-        </button>
+        <div className="battle-buttons">
+          <button className="cancel-button" disabled={buttonsLocked} onClick={() => retreat()}>
+            Retreat
+          </button>
 
-        {battle.enemies.length && battle.enemies.some((e) => e.hp > 0) ? (
-          <button
-            className="confirm-button"
-            disabled={buttonsLocked}
-            onClick={() => {
-              battle.runRound();
-            }}
-          >
-            Run Round
-          </button>
-        ) : (
-          <button className="confirm-button" disabled={buttonsLocked} onClick={runAfterWaveClear}>
-            Next Wave
-          </button>
-        )}
-      </div>
+          {battle.enemies.length && battle.enemies.some((e) => e.hp > 0) ? (
+            <button
+              className="confirm-button"
+              disabled={buttonsLocked}
+              onClick={() => {
+                battle.runRound();
+              }}
+            >
+              Run Round
+            </button>
+          ) : (
+            <button className="confirm-button" disabled={buttonsLocked} onClick={runAfterWaveClear}>
+              Next Wave
+            </button>
+          )}
+        </div>
+      </motion.div>
     </div>
   );
 };

--- a/src/pages/Battle/InProgress.tsx
+++ b/src/pages/Battle/InProgress.tsx
@@ -1,6 +1,7 @@
 import { motion, useReducedMotion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 import { useGame } from '../../context/Game';
+import { BattlePhase } from '../../hooks/useBattleState';
 import { isTestMode } from '../../utils/testMode';
 import { AllyCard } from './Cards/Ally';
 import { buildTransition, MOTION_DURATION, MOTION_EASING } from '../../motion/transitions';
@@ -18,17 +19,26 @@ export interface BattleInProgressProps {
 
 export const BattleInProgress = ({ exitPresentation = false }: BattleInProgressProps) => {
   const { battle } = useGame();
-  const { currentWave, enemies, team, actionQueue, playActionQueue, isRunningRound, retreat } =
-    battle;
+  const {
+    currentWave,
+    enemies,
+    team,
+    actionQueue,
+    playActionQueue,
+    isRunningRound,
+    retreat,
+    phase,
+  } = battle;
   const [waveClearPlaying, setWaveClearPlaying] = useState(false);
   const waveClearTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const shouldReduceMotion = (useReducedMotion() ?? false) || isTestMode();
 
   useEffect(() => {
+    if (phase !== BattlePhase.Inprogress) return;
     if (actionQueue && actionQueue.length > 0 && isRunningRound === false) {
       playActionQueue();
     }
-  }, [playActionQueue, actionQueue, isRunningRound]);
+  }, [playActionQueue, actionQueue, isRunningRound, phase]);
 
   useEffect(() => {
     return () => {

--- a/src/pages/Battle/index.tsx
+++ b/src/pages/Battle/index.tsx
@@ -1,13 +1,19 @@
 import { useNavigate } from 'react-router-dom';
+import { useReducedMotion } from 'motion/react';
 import { useGame } from '../../context/Game';
 import { BattlePhase } from '../../hooks/useBattleState';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { BattleInProgress } from './InProgress';
 import { BattlePrep } from './Prep';
 import { BattleOutcome } from './BattleOutcome';
 import { useBattlePageHitFeedback } from './useBattlePageHitFeedback';
 import { useSceneCanvas } from '../../hooks/useSceneCanvas';
-import { Arena } from './Arena';
+import {
+  Arena,
+  CAMERA_EMPHASIS_HOLD_MS,
+  CAMERA_EMPHASIS_OUT_MS,
+} from './Arena';
+import { DEFEAT_SINK_DURATION_SEC } from './CombatantModel';
 import {
   getEnemiesDefeatedCount,
   computeBattleExpTotal,
@@ -16,12 +22,16 @@ import {
 } from '../../game/BattleRewards';
 import { KraataReward } from '../../types/Kraata';
 
+/** After Victory/Defeat phase, wait for defeat sink/fade + camera zoom-out before showing rewards UI. */
+const OUTCOME_VISUAL_CUSHION_SEC = 0.12;
+
 export const BattlePage: React.FC = () => {
   const navigate = useNavigate();
   const { battle, applyBattleRewards, completedQuests, collectedKrana } = useGame();
   const { currentEncounter, phase, currentWave, enemies, team } = battle;
   const { setScene } = useSceneCanvas();
   const battlePageRootClass = useBattlePageHitFeedback();
+  const reduceMotion = useReducedMotion() ?? false;
 
   const kranaRewardsRef = useRef<ReturnType<typeof computeKranaRewardsForBattle> | null>(null);
   const kraataRewardsRef = useRef<KraataReward[] | null>(null);
@@ -59,6 +69,36 @@ export const BattlePage: React.FC = () => {
 
   const kranaRewards = kranaRewardsRef.current ?? [];
   const kraataRewards = kraataRewardsRef.current ?? [];
+
+  const outcomeVisualDelaySec = reduceMotion
+    ? 0
+    : DEFEAT_SINK_DURATION_SEC +
+      (CAMERA_EMPHASIS_HOLD_MS + CAMERA_EMPHASIS_OUT_MS) / 1000 +
+      OUTCOME_VISUAL_CUSHION_SEC;
+
+  const [showOutcomeContent, setShowOutcomeContent] = useState(
+    () =>
+      phase === BattlePhase.Retreated ||
+      reduceMotion ||
+      (phase !== BattlePhase.Victory && phase !== BattlePhase.Defeat)
+  );
+
+  useEffect(() => {
+    if (phase === BattlePhase.Retreated) {
+      setShowOutcomeContent(true);
+      return;
+    }
+    if (phase === BattlePhase.Victory || phase === BattlePhase.Defeat) {
+      if (reduceMotion) {
+        setShowOutcomeContent(true);
+        return;
+      }
+      setShowOutcomeContent(false);
+      const delayMs = Math.round(outcomeVisualDelaySec * 1000);
+      const id = window.setTimeout(() => setShowOutcomeContent(true), delayMs);
+      return () => window.clearTimeout(id);
+    }
+  }, [phase, reduceMotion, outcomeVisualDelaySec]);
 
   useEffect(() => {
     if (!currentEncounter) {
@@ -129,6 +169,7 @@ export const BattlePage: React.FC = () => {
           kranaRewards={kranaRewards}
           kraataRewards={kraataRewards}
           onCollect={handleCollectRewards}
+          showContent={showOutcomeContent}
         />
       </div>
     );

--- a/src/pages/Battle/index.tsx
+++ b/src/pages/Battle/index.tsx
@@ -1,19 +1,13 @@
 import { useNavigate } from 'react-router-dom';
-import { useReducedMotion } from 'motion/react';
 import { useGame } from '../../context/Game';
 import { BattlePhase } from '../../hooks/useBattleState';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { BattleInProgress } from './InProgress';
 import { BattlePrep } from './Prep';
 import { BattleOutcome } from './BattleOutcome';
 import { useBattlePageHitFeedback } from './useBattlePageHitFeedback';
 import { useSceneCanvas } from '../../hooks/useSceneCanvas';
-import {
-  Arena,
-  CAMERA_EMPHASIS_HOLD_MS,
-  CAMERA_EMPHASIS_OUT_MS,
-} from './Arena';
-import { DEFEAT_SINK_DURATION_SEC } from './CombatantModel';
+import { Arena } from './Arena';
 import {
   getEnemiesDefeatedCount,
   computeBattleExpTotal,
@@ -22,16 +16,12 @@ import {
 } from '../../game/BattleRewards';
 import { KraataReward } from '../../types/Kraata';
 
-/** After Victory/Defeat phase, wait for defeat sink/fade + camera zoom-out before showing rewards UI. */
-const OUTCOME_VISUAL_CUSHION_SEC = 0.12;
-
 export const BattlePage: React.FC = () => {
   const navigate = useNavigate();
   const { battle, applyBattleRewards, completedQuests, collectedKrana } = useGame();
   const { currentEncounter, phase, currentWave, enemies, team } = battle;
   const { setScene } = useSceneCanvas();
   const battlePageRootClass = useBattlePageHitFeedback();
-  const reduceMotion = useReducedMotion() ?? false;
 
   const kranaRewardsRef = useRef<ReturnType<typeof computeKranaRewardsForBattle> | null>(null);
   const kraataRewardsRef = useRef<KraataReward[] | null>(null);
@@ -69,36 +59,6 @@ export const BattlePage: React.FC = () => {
 
   const kranaRewards = kranaRewardsRef.current ?? [];
   const kraataRewards = kraataRewardsRef.current ?? [];
-
-  const outcomeVisualDelaySec = reduceMotion
-    ? 0
-    : DEFEAT_SINK_DURATION_SEC +
-      (CAMERA_EMPHASIS_HOLD_MS + CAMERA_EMPHASIS_OUT_MS) / 1000 +
-      OUTCOME_VISUAL_CUSHION_SEC;
-
-  const [showOutcomeContent, setShowOutcomeContent] = useState(
-    () =>
-      phase === BattlePhase.Retreated ||
-      reduceMotion ||
-      (phase !== BattlePhase.Victory && phase !== BattlePhase.Defeat)
-  );
-
-  useEffect(() => {
-    if (phase === BattlePhase.Retreated) {
-      setShowOutcomeContent(true);
-      return;
-    }
-    if (phase === BattlePhase.Victory || phase === BattlePhase.Defeat) {
-      if (reduceMotion) {
-        setShowOutcomeContent(true);
-        return;
-      }
-      setShowOutcomeContent(false);
-      const delayMs = Math.round(outcomeVisualDelaySec * 1000);
-      const id = window.setTimeout(() => setShowOutcomeContent(true), delayMs);
-      return () => window.clearTimeout(id);
-    }
-  }, [phase, reduceMotion, outcomeVisualDelaySec]);
 
   useEffect(() => {
     if (!currentEncounter) {
@@ -169,7 +129,6 @@ export const BattlePage: React.FC = () => {
           kranaRewards={kranaRewards}
           kraataRewards={kraataRewards}
           onCollect={handleCollectRewards}
-          showContent={showOutcomeContent}
         />
       </div>
     );

--- a/src/pages/Battle/index.tsx
+++ b/src/pages/Battle/index.tsx
@@ -100,11 +100,16 @@ export const BattlePage: React.FC = () => {
     phase === BattlePhase.Defeat ||
     phase === BattlePhase.Victory
   ) {
-    if (
+    const waitingOnOutcomePresentation =
       (phase === BattlePhase.Victory || phase === BattlePhase.Defeat) &&
-      !outcomePresentationReady
-    ) {
-      return <div className={battlePageRootClass} />;
+      !outcomePresentationReady;
+
+    if (waitingOnOutcomePresentation) {
+      return (
+        <div className={battlePageRootClass}>
+          <BattleInProgress exitPresentation />
+        </div>
+      );
     }
 
     const enemiesDefeated =

--- a/src/pages/Battle/index.tsx
+++ b/src/pages/Battle/index.tsx
@@ -19,7 +19,8 @@ import { KraataReward } from '../../types/Kraata';
 export const BattlePage: React.FC = () => {
   const navigate = useNavigate();
   const { battle, applyBattleRewards, completedQuests, collectedKrana } = useGame();
-  const { currentEncounter, phase, currentWave, enemies, team } = battle;
+  const { currentEncounter, phase, currentWave, enemies, team, outcomePresentationReady } =
+    battle;
   const { setScene } = useSceneCanvas();
   const battlePageRootClass = useBattlePageHitFeedback();
 
@@ -99,6 +100,13 @@ export const BattlePage: React.FC = () => {
     phase === BattlePhase.Defeat ||
     phase === BattlePhase.Victory
   ) {
+    if (
+      (phase === BattlePhase.Victory || phase === BattlePhase.Defeat) &&
+      !outcomePresentationReady
+    ) {
+      return <div className={battlePageRootClass} />;
+    }
+
     const enemiesDefeated =
       currentEncounter && getEnemiesDefeatedCount(currentEncounter, phase, currentWave, enemies);
     const expTotal =

--- a/src/styles/battle.scss
+++ b/src/styles/battle.scss
@@ -255,6 +255,12 @@
     }
   }
 
+  &-in-progress__chrome {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
   &-buttons {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Victory/Defeat **`battle.phase`** transitions **immediately** when HP conditions are met, so the battle page leaves `Inprogress` and **“Next Wave” / combat flow cannot resume** during the post-fight animation window.

A separate flag **`outcomePresentationReady`** on `BattleState` controls **presentation only**:

- Starts `false` when entering `Victory` or `Defeat` (unless reduced motion, then `true` immediately).
- After `getBattleOutcomePhaseDelayMs`, becomes `true` so **bottom nav** and **BattleOutcome** appear together.
- `Retreated` does not use this flag (nav/outcome stay immediate).
- Timers cleared on retreat, endBattle, startBattle.

**Battle chrome polish:** While waiting on `outcomePresentationReady`, `BattlePage` keeps **`BattleInProgress`** mounted with **`exitPresentation`**, which fades out (opacity + slight upward motion) the wave title, ally cards, and buttons using the same motion tokens as the rest of the app. Buttons are disabled and non-interactive during this exit.

## Test plan

- [ ] Clear final wave: no “Next Wave” after victory; wave/ally UI eases out; then nav + outcome together.
- [ ] Party wipe: same for defeat.
- [ ] Retreat: unchanged.
- [ ] Reduced motion: no presentation delay; exit animation duration zeroed by `buildTransition`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7e7a4b8-bf66-49cb-8ea3-ddb2247b7601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7e7a4b8-bf66-49cb-8ea3-ddb2247b7601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

