### PR TITLE
Rename useEyeMeshes to useCharacterBloomMeshes

### DIFF
--- a/src/components/CharacterScene/index.tsx
+++ b/src/components/CharacterScene/index.tsx
@@ -22,7 +22,7 @@ import { TahuMataModel } from './Mata/TahuMataModel';
 import { TahuNuvaModel } from './Nuva/TahuNuvaModel';
 import { GaliNuvaModel } from './Nuva/GaliNuvaModel';
 import { BohrokModel } from './BohrokModel';
-import { useEyeMeshes } from './selectiveBloom';
+import { useCharacterBloomMeshes } from './selectiveBloom';
 import { StableSelectiveBloom } from './StableSelectiveBloom';
 import { OnuaNuvaModel } from './Nuva/OnuaNuvaModel';
 import { PohatuNuvaModel } from './Nuva/PohatuNuvaModel';
@@ -132,7 +132,7 @@ function CharacterFraming() {
 export function CharacterScene({ matoran }: { matoran: BaseMatoran & RecruitedCharacterData }) {
   const characterRootRef = useRef<Object3D>(null);
   const [lightsForBloom, setLightsForBloom] = useState<Object3D[]>([]);
-  const eyeMeshes = useEyeMeshes(characterRootRef, matoran);
+  const bloomMeshes = useCharacterBloomMeshes(characterRootRef, matoran);
   const { shadowsEnabled } = useSettings();
   const effectiveShadows = shadowsEnabled && shouldEnableShadows();
   useEffect(() => {
@@ -221,7 +221,7 @@ export function CharacterScene({ matoran }: { matoran: BaseMatoran & RecruitedCh
         />
         {lightsForBloom.length > 0 && shouldEnableSelectiveBloom() ? (
           <StableSelectiveBloom
-            selection={eyeMeshes}
+            selection={bloomMeshes}
             lights={lightsForBloom}
             luminanceThreshold={0.25}
             luminanceSmoothing={0.5}

--- a/src/components/CharacterScene/selectiveBloom.ts
+++ b/src/components/CharacterScene/selectiveBloom.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from 'react';
+import { useLayoutEffect, useState, type RefObject } from 'react';
 import { Mesh, MeshStandardMaterial, Object3D } from 'three';
 
 import { BaseMatoran, RecruitedCharacterData } from '../../types/Matoran';
@@ -41,29 +41,32 @@ function collectBloomMeshes(root: Object3D): Object3D[] {
   return collected;
 }
 
-/** Collects eye and mask meshes that have emissive material, for selective bloom in CharacterScene. */
-export function useEyeMeshes(
-  characterRootRef: React.RefObject<Object3D | null>,
+/**
+ * Meshes under the character root that receive selective bloom (eyes, mask
+ * emissive, etc.).
+ */
+export function useCharacterBloomMeshes(
+  characterRootRef: RefObject<Object3D | null>,
   matoran: BaseMatoran & RecruitedCharacterData
 ) {
-  const [eyeMeshes, setEyeMeshes] = useState<Object3D[]>([]);
+  const [bloomMeshes, setBloomMeshes] = useState<Object3D[]>([]);
 
   useLayoutEffect(() => {
     const root = characterRootRef.current;
     if (!root) {
-      setEyeMeshes([]);
+      setBloomMeshes([]);
       return;
     }
-    const id = setTimeout(() => setEyeMeshes(collectBloomMeshes(root)), 0);
+    const id = setTimeout(() => setBloomMeshes(collectBloomMeshes(root)), 0);
     return () => clearTimeout(id);
   }, [matoran, characterRootRef]);
 
-  return eyeMeshes;
+  return bloomMeshes;
 }
 
 /** Collects all meshes with emissive material (emissiveIntensity > 0) for selective bloom. */
 export function useEmissiveMeshes(
-  rootRef: React.RefObject<Object3D | null>,
+  rootRef: RefObject<Object3D | null>,
   deps: React.DependencyList
 ) {
   const [meshes, setMeshes] = useState<Object3D[]>([]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renames the selective-bloom collection hook and the variable passed to `StableSelectiveBloom` so names match behavior (eyes + mask emissive + other glow targets).

## Changes

- `useEyeMeshes` → **`useCharacterBloomMeshes`** in `selectiveBloom.ts` (internal state: `bloomMeshes`)
- **`CharacterScene`**: `bloomMeshes` + `selection={bloomMeshes}` for `StableSelectiveBloom`
- `useEmissiveMeshes`: use `RefObject` from React instead of `React.RefObject` for consistency

## Testing

- `yarn lint`
- `yarn test:ci`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fdf5072-4c2a-47d6-b6c8-cf9534c58207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fdf5072-4c2a-47d6-b6c8-cf9534c58207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

