### PR TITLE
Add Debug character creation flag for creation stage picker

### DIFF
--- a/src/context/Settings.tsx
+++ b/src/context/Settings.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import {
-  getCreationDebugEditable,
+  getDebugCharacterCreation,
   getDebugMode,
   getPerformanceMonitorEnabled,
   getShadowsEnabled,
   getTelemetryEnabled,
-  saveCreationDebugEditable,
+  saveDebugCharacterCreation,
   saveDebugMode,
   savePerformanceMonitorEnabled,
   saveShadowsEnabled,
@@ -15,7 +15,7 @@ import {
 import { SettingsContext } from './SettingsContext';
 
 export function SettingsProvider({ children }: { children: React.ReactNode }) {
-  const [creationDebugEditable, setCreationDebugEditableState] = useState(getCreationDebugEditable);
+  const [debugCharacterCreation, setDebugCharacterCreationState] = useState(getDebugCharacterCreation);
   const [debugMode, setDebugModeState] = useState(getDebugMode);
   const [performanceMonitorEnabled, setPerformanceMonitorEnabledState] = useState(
     getPerformanceMonitorEnabled
@@ -24,8 +24,8 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
   const [telemetryEnabled, setTelemetryEnabledState] = useState(getTelemetryEnabled);
 
   useEffect(() => {
-    saveCreationDebugEditable(creationDebugEditable);
-  }, [creationDebugEditable]);
+    saveDebugCharacterCreation(debugCharacterCreation);
+  }, [debugCharacterCreation]);
 
   useEffect(() => {
     saveDebugMode(debugMode);
@@ -47,10 +47,10 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
   return (
     <SettingsContext.Provider
       value={{
-        creationDebugEditable,
+        debugCharacterCreation,
         debugMode,
         performanceMonitorEnabled,
-        setCreationDebugEditable: setCreationDebugEditableState,
+        setDebugCharacterCreation: setDebugCharacterCreationState,
         setDebugMode: setDebugModeState,
         setPerformanceMonitorEnabled: setPerformanceMonitorEnabledState,
         setShadowsEnabled: setShadowsEnabledState,

--- a/src/context/Settings.tsx
+++ b/src/context/Settings.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 import {
+  getCreationDebugEditable,
   getDebugMode,
   getPerformanceMonitorEnabled,
   getShadowsEnabled,
   getTelemetryEnabled,
+  saveCreationDebugEditable,
   saveDebugMode,
   savePerformanceMonitorEnabled,
   saveShadowsEnabled,
@@ -13,12 +15,17 @@ import {
 import { SettingsContext } from './SettingsContext';
 
 export function SettingsProvider({ children }: { children: React.ReactNode }) {
+  const [creationDebugEditable, setCreationDebugEditableState] = useState(getCreationDebugEditable);
   const [debugMode, setDebugModeState] = useState(getDebugMode);
   const [performanceMonitorEnabled, setPerformanceMonitorEnabledState] = useState(
     getPerformanceMonitorEnabled
   );
   const [shadowsEnabled, setShadowsEnabledState] = useState(getShadowsEnabled);
   const [telemetryEnabled, setTelemetryEnabledState] = useState(getTelemetryEnabled);
+
+  useEffect(() => {
+    saveCreationDebugEditable(creationDebugEditable);
+  }, [creationDebugEditable]);
 
   useEffect(() => {
     saveDebugMode(debugMode);
@@ -40,8 +47,10 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
   return (
     <SettingsContext.Provider
       value={{
+        creationDebugEditable,
         debugMode,
         performanceMonitorEnabled,
+        setCreationDebugEditable: setCreationDebugEditableState,
         setDebugMode: setDebugModeState,
         setPerformanceMonitorEnabled: setPerformanceMonitorEnabledState,
         setShadowsEnabled: setShadowsEnabledState,

--- a/src/context/SettingsContext.ts
+++ b/src/context/SettingsContext.ts
@@ -1,6 +1,8 @@
 import { createContext } from 'react';
 
 export interface SettingsState {
+  creationDebugEditable: boolean;
+  setCreationDebugEditable: (value: boolean) => void;
   debugMode: boolean;
   setDebugMode: (value: boolean) => void;
   performanceMonitorEnabled: boolean;

--- a/src/context/SettingsContext.ts
+++ b/src/context/SettingsContext.ts
@@ -1,8 +1,8 @@
 import { createContext } from 'react';
 
 export interface SettingsState {
-  creationDebugEditable: boolean;
-  setCreationDebugEditable: (value: boolean) => void;
+  debugCharacterCreation: boolean;
+  setDebugCharacterCreation: (value: boolean) => void;
   debugMode: boolean;
   setDebugMode: (value: boolean) => void;
   performanceMonitorEnabled: boolean;

--- a/src/data/gameState.ts
+++ b/src/data/gameState.ts
@@ -44,7 +44,10 @@ export const INITIAL_GAME_STATE: GameState = {
   ): boolean {
     throw new Error('Function not implemented.');
   },
-  createCustomCharacter: function (_base: Omit<BaseMatoran, 'id'>): string | null {
+  createCustomCharacter: function (
+    _base: Omit<BaseMatoran, 'id'>,
+    _extras?: Pick<RecruitedCharacterData, 'customMataModelId'>
+  ): string | null {
     throw new Error('Function not implemented.');
   },
   customCharacters: [],

--- a/src/hooks/useCharactersState.spec.tsx
+++ b/src/hooks/useCharactersState.spec.tsx
@@ -132,6 +132,53 @@ describe('useCharactersState', () => {
     });
   });
 
+  describe('createCustomCharacter', () => {
+    const baseMinusId = (stage: MatoranStage): Omit<BaseMatoran, 'id'> => ({
+      colors: {
+        arms: LegoColor.LightGray,
+        body: LegoColor.LightGray,
+        eyes: LegoColor.TransNeonOrange,
+        face: LegoColor.DarkGray,
+        feet: LegoColor.LightGray,
+        mask: LegoColor.LightGray,
+      },
+      element: ElementTribe.Fire,
+      mask: Mask.Hau,
+      name: 'Test',
+      stage,
+      tags: [MatoranTag.Custom],
+    });
+
+    test('stores customMataModelId on recruit when creating at Toa Mata', () => {
+      const { result } = renderHook(() =>
+        useCharactersState([], [], [], mockProtodermis, mockSetProtodermis)
+      );
+
+      let id: string | null = null;
+      act(() => {
+        id = result.current.createCustomCharacter(baseMinusId(MatoranStage.ToaMata), {
+          customMataModelId: 'Toa_Gali',
+        });
+      });
+
+      expect(id).toBe('custom_0');
+      expect(result.current.recruitedCharacters[0].customMataModelId).toBe('Toa_Gali');
+      expect(result.current.customCharacters[0].stage).toBe(MatoranStage.ToaMata);
+    });
+
+    test('defaults customMataModelId when Toa Mata extras omitted', () => {
+      const { result } = renderHook(() =>
+        useCharactersState([], [], [], mockProtodermis, mockSetProtodermis)
+      );
+
+      act(() => {
+        result.current.createCustomCharacter(baseMinusId(MatoranStage.ToaMata));
+      });
+
+      expect(result.current.recruitedCharacters[0].customMataModelId).toBe('Toa_Tahu');
+    });
+  });
+
   describe('assignJobToMatoran', () => {
     test('assigns job to specific matoran', () => {
       const initialRecruited: RecruitedCharacterData[] = [

--- a/src/hooks/useCharactersState.tsx
+++ b/src/hooks/useCharactersState.tsx
@@ -5,9 +5,11 @@ import {
   CREATE_CUSTOM_CHARACTER_ID,
   ListedCharacterData,
   Mask,
+  MatoranStage,
   RecruitedCharacterData,
   isCustomCharacterId,
 } from '../types/Matoran';
+import { DEFAULT_CUSTOM_MATA_MODEL_ID } from '../game/customMataBuild';
 import { MatoranJob } from '../types/Jobs';
 import { recruitMatoran, assignJob, removeJob } from '../services/matoranUtils';
 import { getBuyableCharacters, isCharacterRecruited } from '../game/Recruitment';
@@ -91,13 +93,23 @@ export function useCharactersState(
     return id;
   };
 
-  const createCustomCharacter = (base: Omit<BaseMatoran, 'id'>): string | null => {
+  const createCustomCharacter = (
+    base: Omit<BaseMatoran, 'id'>,
+    extras?: Pick<RecruitedCharacterData, 'customMataModelId'>
+  ): string | null => {
     if (protodermis < CUSTOM_CHARACTER_COST) return null;
     const id = nextCustomId(customCharacters);
     const newBase: BaseMatoran = { ...base, id };
     registerCustomCharacterInDex(newBase);
     setCustomCharacters((prev) => [...prev, newBase]);
-    setRecruitedCharacters((prev) => [...prev, { exp: 0, id }]);
+    const recruitEntry: RecruitedCharacterData = {
+      exp: 0,
+      id,
+      ...(base.stage === MatoranStage.ToaMata
+        ? { customMataModelId: extras?.customMataModelId ?? DEFAULT_CUSTOM_MATA_MODEL_ID }
+        : {}),
+    };
+    setRecruitedCharacters((prev) => [...prev, recruitEntry]);
     setProtodermis(protodermis - CUSTOM_CHARACTER_COST);
     return id;
   };

--- a/src/pages/CharacterCreation/index.tsx
+++ b/src/pages/CharacterCreation/index.tsx
@@ -6,6 +6,7 @@ import { Modal } from '../../components/Modal';
 import { CharacterScene } from '../../components/CharacterScene';
 import { useSceneCanvas } from '../../hooks/useSceneCanvas';
 import { useGame } from '../../context/Game';
+import { useSettings } from '../../context/useSettings';
 import { getRecruitedMatoran } from '../../services/matoranUtils';
 import {
   getOrderedEditableColorTabs,
@@ -60,6 +61,16 @@ const SELECTABLE_ELEMENTS: ElementTribe[] = [
   ElementTribe.Earth,
   ElementTribe.Light,
   ElementTribe.Shadow,
+];
+
+/** Stages exposed when settings "Editable" creation debug is on (new characters only). */
+const DEBUG_CREATION_STAGES: MatoranStage[] = [
+  MatoranStage.Diminished,
+  MatoranStage.Rebuilt,
+  MatoranStage.Metru,
+  MatoranStage.ToaMata,
+  MatoranStage.ToaNuva,
+  MatoranStage.Turaga,
 ];
 
 /** Subset of LegoColors useful as body/armor colors for a custom character. */
@@ -140,6 +151,7 @@ export const CharacterCreation: React.FC = () => {
     updateCustomCharacter,
   } = useGame();
   const { setScene } = useSceneCanvas();
+  const { creationDebugEditable } = useSettings();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -158,12 +170,23 @@ export const CharacterCreation: React.FC = () => {
     [customCharacters, customizeId, recruitedCharacters]
   );
 
+  const [debugStartingStage, setDebugStartingStage] = useState<MatoranStage>(MatoranStage.Diminished);
+
   const creationStage = useMemo(() => {
     if (isEditMode && customizeId) {
       return getRecruitedMatoran(customizeId, recruitedCharacters).stage;
     }
+    if (creationDebugEditable) {
+      return debugStartingStage;
+    }
     return MatoranStage.Diminished;
-  }, [customizeId, isEditMode, recruitedCharacters]);
+  }, [
+    creationDebugEditable,
+    customizeId,
+    debugStartingStage,
+    isEditMode,
+    recruitedCharacters,
+  ]);
 
   const [name, setName] = useState(DEFAULT_CUSTOM_MATORAN_NAME);
   const [showCreateConfirm, setShowCreateConfirm] = useState(false);
@@ -321,16 +344,19 @@ export const CharacterCreation: React.FC = () => {
       }
       return;
     }
-    const resolvedColors = normalizeCustomCharacterColorsForStage(MatoranStage.Diminished, colors);
-    const id = createCustomCharacter({
-      colors: resolvedColors,
-      element,
-      isMaskTransparent,
-      mask,
-      name: trimmedName,
-      stage: MatoranStage.Diminished,
-      tags: [MatoranTag.Custom],
-    });
+    const resolvedColors = normalizeCustomCharacterColorsForStage(creationStage, colors);
+    const id = createCustomCharacter(
+      {
+        colors: resolvedColors,
+        element,
+        isMaskTransparent,
+        mask,
+        name: trimmedName,
+        stage: creationStage,
+        tags: [MatoranTag.Custom],
+      },
+      creationStage === MatoranStage.ToaMata ? { customMataModelId: mataBuildId } : undefined
+    );
     if (id) {
       setShowCreateConfirm(false);
       navigate(`/characters/${id}`);
@@ -350,6 +376,23 @@ export const CharacterCreation: React.FC = () => {
     <div className={`character-creation element-${element}`}>
       <div className="character-creation-preview" />
       <div className="character-creation-form">
+        {creationDebugEditable && !isEditMode && (
+          <label className="field">
+            <span className="field-label">Stage (debug)</span>
+            <select
+              className="field-input"
+              value={debugStartingStage}
+              onChange={(e) => setDebugStartingStage(e.target.value as MatoranStage)}
+            >
+              {DEBUG_CREATION_STAGES.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
         <label className="field">
           <span className="field-label">Name</span>
           <input
@@ -395,7 +438,7 @@ export const CharacterCreation: React.FC = () => {
           </div>
         </div>
 
-        {isEditMode && creationStage === MatoranStage.ToaMata && (
+        {(isEditMode || creationDebugEditable) && creationStage === MatoranStage.ToaMata && (
           <label className="field">
             <span className="field-label">Toa build (model)</span>
             <select

--- a/src/pages/CharacterCreation/index.tsx
+++ b/src/pages/CharacterCreation/index.tsx
@@ -63,7 +63,7 @@ const SELECTABLE_ELEMENTS: ElementTribe[] = [
   ElementTribe.Shadow,
 ];
 
-/** Stages exposed when settings "Editable" creation debug is on (new characters only). */
+/** Stages exposed when "Debug character creation" is on (new characters only). */
 const DEBUG_CREATION_STAGES: MatoranStage[] = [
   MatoranStage.Diminished,
   MatoranStage.Rebuilt,
@@ -151,7 +151,7 @@ export const CharacterCreation: React.FC = () => {
     updateCustomCharacter,
   } = useGame();
   const { setScene } = useSceneCanvas();
-  const { creationDebugEditable } = useSettings();
+  const { debugCharacterCreation } = useSettings();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -176,12 +176,12 @@ export const CharacterCreation: React.FC = () => {
     if (isEditMode && customizeId) {
       return getRecruitedMatoran(customizeId, recruitedCharacters).stage;
     }
-    if (creationDebugEditable) {
+    if (debugCharacterCreation) {
       return debugStartingStage;
     }
     return MatoranStage.Diminished;
   }, [
-    creationDebugEditable,
+    debugCharacterCreation,
     customizeId,
     debugStartingStage,
     isEditMode,
@@ -376,7 +376,7 @@ export const CharacterCreation: React.FC = () => {
     <div className={`character-creation element-${element}`}>
       <div className="character-creation-preview" />
       <div className="character-creation-form">
-        {creationDebugEditable && !isEditMode && (
+        {debugCharacterCreation && !isEditMode && (
           <label className="field">
             <span className="field-label">Stage (debug)</span>
             <select
@@ -438,7 +438,7 @@ export const CharacterCreation: React.FC = () => {
           </div>
         </div>
 
-        {(isEditMode || creationDebugEditable) && creationStage === MatoranStage.ToaMata && (
+        {(isEditMode || debugCharacterCreation) && creationStage === MatoranStage.ToaMata && (
           <label className="field">
             <span className="field-label">Toa build (model)</span>
             <select

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -8,10 +8,10 @@ const showTelemetryOption = !!getTelemetryUrl();
 
 export default function SettingsPage() {
   const {
-    creationDebugEditable,
+    debugCharacterCreation,
     debugMode,
     performanceMonitorEnabled,
-    setCreationDebugEditable,
+    setDebugCharacterCreation,
     setDebugMode,
     setPerformanceMonitorEnabled,
     setShadowsEnabled,
@@ -245,10 +245,10 @@ export default function SettingsPage() {
           />
         </label>
         <label className="settings-option">
-          <span>Editable</span>
+          <span>Debug character creation</span>
           <div
-            className={`toggle-placeholder ${creationDebugEditable ? 'on' : ''}`}
-            onClick={() => setCreationDebugEditable(!creationDebugEditable)}
+            className={`toggle-placeholder ${debugCharacterCreation ? 'on' : ''}`}
+            onClick={() => setDebugCharacterCreation(!debugCharacterCreation)}
           />
         </label>
         <label className="settings-option">

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -8,8 +8,10 @@ const showTelemetryOption = !!getTelemetryUrl();
 
 export default function SettingsPage() {
   const {
+    creationDebugEditable,
     debugMode,
     performanceMonitorEnabled,
+    setCreationDebugEditable,
     setDebugMode,
     setPerformanceMonitorEnabled,
     setShadowsEnabled,
@@ -240,6 +242,13 @@ export default function SettingsPage() {
           <div
             className={`toggle-placeholder ${debugMode ? 'on' : ''}`}
             onClick={() => setDebugMode(!debugMode)}
+          />
+        </label>
+        <label className="settings-option">
+          <span>Editable</span>
+          <div
+            className={`toggle-placeholder ${creationDebugEditable ? 'on' : ''}`}
+            onClick={() => setCreationDebugEditable(!creationDebugEditable)}
           />
         </label>
         <label className="settings-option">

--- a/src/services/gamePersistence.ts
+++ b/src/services/gamePersistence.ts
@@ -177,25 +177,37 @@ export function savePerformanceMonitorEnabled(value: boolean) {
   localStorage.setItem('PERFORMANCE_MONITOR_ENABLED', JSON.stringify(performanceMonitorEnabled));
 }
 
-let creationDebugEditable: boolean | undefined;
+let debugCharacterCreation: boolean | undefined;
 
-export function getCreationDebugEditable() {
-  if (creationDebugEditable !== undefined) {
-    return creationDebugEditable;
+const DEBUG_CHARACTER_CREATION_KEY = 'DEBUG_CHARACTER_CREATION';
+const LEGACY_DEBUG_CHARACTER_CREATION_KEY = 'CHARACTER_CREATION_DEBUG_EDITABLE';
+
+export function getDebugCharacterCreation() {
+  if (debugCharacterCreation !== undefined) {
+    return debugCharacterCreation;
   }
-  const stored = localStorage.getItem('CHARACTER_CREATION_DEBUG_EDITABLE');
+  const stored = localStorage.getItem(DEBUG_CHARACTER_CREATION_KEY);
   if (stored !== null) {
     const parsed = JSON.parse(stored) as boolean;
-    creationDebugEditable = parsed;
+    debugCharacterCreation = parsed;
     return parsed;
   }
-  creationDebugEditable = false;
+  const legacy = localStorage.getItem(LEGACY_DEBUG_CHARACTER_CREATION_KEY);
+  if (legacy !== null) {
+    const parsed = JSON.parse(legacy) as boolean;
+    debugCharacterCreation = parsed;
+    localStorage.setItem(DEBUG_CHARACTER_CREATION_KEY, JSON.stringify(parsed));
+    localStorage.removeItem(LEGACY_DEBUG_CHARACTER_CREATION_KEY);
+    return parsed;
+  }
+  debugCharacterCreation = false;
   return false;
 }
 
-export function saveCreationDebugEditable(value: boolean) {
-  creationDebugEditable = value;
-  localStorage.setItem('CHARACTER_CREATION_DEBUG_EDITABLE', JSON.stringify(creationDebugEditable));
+export function saveDebugCharacterCreation(value: boolean) {
+  debugCharacterCreation = value;
+  localStorage.setItem(DEBUG_CHARACTER_CREATION_KEY, JSON.stringify(debugCharacterCreation));
+  localStorage.removeItem(LEGACY_DEBUG_CHARACTER_CREATION_KEY);
 }
 
 let telemetryEnabled: boolean | undefined;

--- a/src/services/gamePersistence.ts
+++ b/src/services/gamePersistence.ts
@@ -177,6 +177,27 @@ export function savePerformanceMonitorEnabled(value: boolean) {
   localStorage.setItem('PERFORMANCE_MONITOR_ENABLED', JSON.stringify(performanceMonitorEnabled));
 }
 
+let creationDebugEditable: boolean | undefined;
+
+export function getCreationDebugEditable() {
+  if (creationDebugEditable !== undefined) {
+    return creationDebugEditable;
+  }
+  const stored = localStorage.getItem('CHARACTER_CREATION_DEBUG_EDITABLE');
+  if (stored !== null) {
+    const parsed = JSON.parse(stored) as boolean;
+    creationDebugEditable = parsed;
+    return parsed;
+  }
+  creationDebugEditable = false;
+  return false;
+}
+
+export function saveCreationDebugEditable(value: boolean) {
+  creationDebugEditable = value;
+  localStorage.setItem('CHARACTER_CREATION_DEBUG_EDITABLE', JSON.stringify(creationDebugEditable));
+}
+
 let telemetryEnabled: boolean | undefined;
 
 /** Returns true only if the user has explicitly chosen a telemetry preference. */

--- a/src/types/GameState.ts
+++ b/src/types/GameState.ts
@@ -46,7 +46,10 @@ export type GameState = {
    * stores its base data in `customCharacters`, deducts the cost, and adds it to
    * `recruitedCharacters`. Returns the created id, or null if it could not be created.
    */
-  createCustomCharacter: (base: Omit<BaseMatoran, 'id'>) => string | null;
+  createCustomCharacter: (
+    base: Omit<BaseMatoran, 'id'>,
+    extras?: Pick<RecruitedCharacterData, 'customMataModelId'>
+  ) => string | null;
   /**
    * Registers a custom character base entry received from a share link, without
    * recruiting it. Appears in the buyable list until recruited or dismissed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Debug character creation** toggle under Settings (next to Quest Debug mode). When enabled, the new-custom-character creation screen shows a **Stage (debug)** select at the top of the form so testers can start at Diminished, Rebuilt, Metru, Toa Mata, Toa Nuva, or Turaga without evolving through the game.

## Implementation notes

- Preference is stored in `localStorage` as `DEBUG_CHARACTER_CREATION` (JSON boolean). If the older `CHARACTER_CREATION_DEBUG_EDITABLE` key exists from a prior build, it is migrated once on read.
- `createCustomCharacter` accepts an optional second argument with `customMataModelId` so Toa Mata created this way persist the chosen Mata build on the recruit record (defaults to `Toa_Tahu` when omitted).
- Unit tests cover Toa Mata creation with and without an explicit Mata id.

## How to verify

1. Settings → turn on **Debug character creation**.
2. Recruitment → create a new custom character → choose **Toa Mata** in the debug stage dropdown and pick a **Toa build** if needed → create and confirm the character appears with the expected model.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac2807d9-bcb8-4c3e-8ac9-63dfa1924f4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac2807d9-bcb8-4c3e-8ac9-63dfa1924f4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

