### PR TITLE
Fix inconsistent blank line in generated quest-graph.md

### DIFF
--- a/public/quest-graph.md
+++ b/public/quest-graph.md
@@ -455,5 +455,4 @@ classDef completed fill:#22c55e,stroke:#16a34a,stroke-width:3px,color:#fff
 classDef active fill:#eab308,stroke:#ca8a04,stroke-width:3px,color:#000
 classDef available fill:#3b82f6,stroke:#2563eb,stroke-width:2px,color:#fff
 classDef locked fill:#6b7280,stroke:#4b5563,stroke-width:2px,color:#d1d5db,opacity:0.6
-
 ```

--- a/src/data/quests/mermaid.ts
+++ b/src/data/quests/mermaid.ts
@@ -78,5 +78,6 @@ export function generateMermaidFlowchart(quests: Quest[], questStates?: QuestSta
     }
   });
 
-  return `\`\`\`mermaid\ngraph TD\n${nodes.join('\n')}\n${edges.join('\n')}\n${classDefs.join('\n')}\n${classAssignments.join('\n')}\n\`\`\``;
+  const lines = ['graph TD', ...nodes, ...edges, ...classDefs, ...classAssignments];
+  return `\`\`\`mermaid\n${lines.join('\n')}\n\`\`\``;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`public/quest-graph.md` kept flipping in git because one workflow wrote a **blank line before the closing** ` ``` ` fence and another removed it.

## Root cause

`generateMermaidFlowchart` in `src/data/quests/mermaid.ts` built the diagram with a template like:

`...\n${classAssignments.join('\n')}\n\`\`\``

When `classAssignments` is empty (always the case for `tools/generate-quest-graph.ts`, which uses default empty quest state buckets), `join('\n')` is the empty string, so the template still inserted the `\n` before the fence—yielding **two** newlines after the last `classDef` line (`\n\n\`\`\``).

That file is rewritten whenever:

- `yarn tsx tools/generate-quest-graph.ts` runs, or  
- Vite dev runs the same script via `vite-plugin-watch` on `src/data/quests/**/*` (see `vite.config.ts`).

Prettier (`yarn format`) leaves that shape unchanged, so the tug-of-war was mainly **auto-regeneration vs manual cleanup** (or editor save without the extra line).

## Fix

Build the fenced body as `['graph TD', ...nodes, ...edges, ...classDefs, ...classAssignments].join('\n')` so empty arrays do not create accidental double newlines. Regenerated `public/quest-graph.md` accordingly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63dc7446-8566-4aaf-89f0-4a316bf9a7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63dc7446-8566-4aaf-89f0-4a316bf9a7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

