### PR TITLE
fix(kit): Toa Mata Face material uses palette face color

### DIFF
--- a/src/game/kit/palettes/mataKitPlayerPalette.ts
+++ b/src/game/kit/palettes/mataKitPlayerPalette.ts
@@ -11,11 +11,14 @@ import { LegoColor } from '../../../types/Colors';
  *   passes `materialColors` (usually built from the exports below). `useKitAttachments`
  *   (`src/hooks/useKitAttachments.ts`) walks each kit mesh, matches **material `.name`** to those
  *   keys (case-insensitive), and resolves `kind: 'palette'` with `resolveColorSource` →
- *   `palette[key]` from that character’s `colors` (optional `weaponGlow` falls back to
- *   `LegoColor.TransNeonYellow` when unset). Slots may also set `metalness`, `roughness`, and
- *   `KitMaterialWeatheredTuning` fields so kit metal reads correctly under the Mata weathered pass.
+ *   `palette[key]` from that character’s `colors` (e.g. `Face` → `colors.face` on MataFace;
+ *   optional `weaponGlow` falls back to `LegoColor.TransNeonYellow` when unset). Slots may also
+ *   set `metalness`, `roughness`, and `KitMaterialWeatheredTuning` fields so kit metal reads
+ *   correctly under the Mata weathered pass.
  */
 export const MATA_KIT_PLAYER_PALETTE_PLASTICS: Partial<Record<string, KitMaterialSlotEntry>> = {
+  /** MataFace mask plastic; GLB material slot name `Face` (same convention as Matoran kit). */
+  Face: { color: { key: 'face', kind: 'palette' }, weathered: true },
   Main: { key: 'body', kind: 'palette' },
   /**
    * Technic silver (light gray): not a palette color slot — override character-level


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`useKitAttachments` tints kit meshes by matching each material’s `.name` to keys in `materialColors`. The shared Mata kit plastics palette (`MATA_KIT_PLAYER_PALETTE_PLASTICS`) defined `Main`, `Metal`, and `Secondary` but not `Face`, so the MataFace GLB’s **Face** slot kept the default light gray. Matoran kit already maps `Face` → `colors.face` via `MATORAN_KIT_PALETTE_FACE`.

## Changes

- Add a `Face` entry to `MATA_KIT_PLAYER_PALETTE_PLASTICS` (`color: face`, `weathered: true`), matching the Matoran face slot behavior.
- Clarify the palette module doc comment.

All six Toa Mata attachment files spread this palette, so no per-character edits were required.

## Testing

- `yarn lint`
- `yarn test:ci`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a47e9ede-2fea-4e5a-99d4-d85d8687e44c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a47e9ede-2fea-4e5a-99d4-d85d8687e44c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

