### PR TITLE
Fix Bohrok feet kit palette typing for production build

### DIFF
--- a/src/game/kit/palettes/bohrokKitPalette.ts
+++ b/src/game/kit/palettes/bohrokKitPalette.ts
@@ -9,7 +9,7 @@ import { mataKitPlayerPaletteGlow } from './mataKitPlayerPalette';
 
 export const BOHROK_KIT_PALETTE_BODY = MATORAN_KIT_PALETTE_BODY;
 export const BOHROK_KIT_PALETTE_ARMS = MATORAN_KIT_PALETTE_ARMS;
-export const BOHROK_KIT_PALETTE_FEET = {
+export const BOHROK_KIT_PALETTE_FEET: Partial<Record<string, KitMaterialSlotEntry>> = {
   Main: {
     color: { key: 'feet', kind: 'palette' },
     envMapIntensity: 0.52,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The production build failed because `BOHROK_KIT_PALETTE_FEET` was an untyped object literal. TypeScript widened nested `color.kind` and `color.key` to `string`, so `Foot_L_1` / `Foot_R_1` attachments in `bohrok.ts` no longer satisfied `KitSocketAttachment.materialColors` (`KitMaterialColorSource` requires literal `"palette"` and a valid `MatoranPaletteKey`).

## Change

Annotate `BOHROK_KIT_PALETTE_FEET` with `Partial<Record<string, KitMaterialSlotEntry>>`, matching other palettes in the same file so contextual typing applies to nested color sources.

## Verification

- `yarn build`
- `yarn lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7270f4be-cc26-43ce-af19-a7887c24b082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7270f4be-cc26-43ce-af19-a7887c24b082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

