### PR TITLE
Disable pinch zoom in PWA via viewport meta

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#2d2d2d" media="(prefers-color-scheme: dark)" />
     <meta name="color-scheme" content="light dark" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the root `viewport` meta tag so the installed PWA behaves more like a native app: `maximum-scale=1` and `user-scalable=no` block browser pinch-to-zoom.

## Notes

This matches common “game shell” behavior but removes zoom for users who rely on it for readability; revisit if accessibility feedback asks for zoom to remain available.

## Test plan

- [ ] Open the app on a phone (or devtools device mode), verify pinch no longer zooms the page.
- [ ] Confirm layout still looks correct at `initial-scale=1`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-294aae6a-0a6c-4df8-a543-8ddccfde7860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-294aae6a-0a6c-4df8-a543-8ddccfde7860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

