### PR TITLE
Fix Kopaka Mata sword palette weaponGlow mapping

### DIFF
--- a/src/data/dex/toa.ts
+++ b/src/data/dex/toa.ts
@@ -64,6 +64,7 @@ export const TOA_DEX = {
       face: LegoColor.DarkGray,
       feet: LegoColor.White,
       mask: LegoColor.White,
+      weaponGlow: LegoColor.MediumBlue,
     },
     element: ElementTribe.Ice,
     id: 'Toa_Kopaka',

--- a/src/game/kit/attachments/Toa Mata/kopaka.ts
+++ b/src/game/kit/attachments/Toa Mata/kopaka.ts
@@ -15,7 +15,7 @@ const KOPAKA_MATA_KIT_PALETTE_COLORS: Partial<Record<string, KitMaterialSlotEntr
 
 const KOPAKA_SWORD_PALETTE_COLORS: Partial<Record<string, KitMaterialSlotEntry>> = {
   ...KOPAKA_MATA_KIT_PALETTE_COLORS,
-  ...mataKitPlayerPaletteWeaponGlow(2.5, 'eyes'),
+  ...mataKitPlayerPaletteWeaponGlow(2.5),
 };
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Kit:** `KOPAKA_SWORD_PALETTE_COLORS` called `mataKitPlayerPaletteWeaponGlow(2.5, 'eyes')`, so the sword `Glow` material always tracked `colors.eyes` instead of the optional `colors.weaponGlow` used by other Toa Mata kits (Tahu, Gali, Lewa). It now uses the default `weaponGlow` key, matching `useKitAttachments` resolution and character creation.
- **Dex:** `Toa_Kopaka` in `TOA_DEX` now includes `weaponGlow: LegoColor.MediumBlue`, identical to canonical eyes, consistent with entries such as Gali and Lewa that declare both.

## Testing

- `yarn lint`
- `yarn test:ci`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a84771e-607a-4716-98ab-03ddd09b1138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a84771e-607a-4716-98ab-03ddd09b1138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

