### PR TITLE
Bohrok krana: use base color only, remove emissive glow

### DIFF
--- a/src/components/CharacterScene/BohrokModel.tsx
+++ b/src/components/CharacterScene/BohrokModel.tsx
@@ -144,7 +144,8 @@ function getKranaMaterial(
   if (!mat) {
     mat = original.clone();
     mat.color.set(color as ColorType);
-    mat.emissive.set(color as ColorType);
+    mat.emissive.set(0x000000);
+    mat.emissiveIntensity = 0;
     kranaMaterialCache.set(cacheKey, mat);
   }
   return mat;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bohrok `Krana` mesh materials were tinted with the breed eye color on both `color` and `emissive`, which made the krana read as self-illuminated and could feed selective bloom. This change keeps the element tint on `color` only and clears `emissive` / `emissiveIntensity` on the cached cloned material.

## Testing

- `yarn lint`
- `yarn test:ci`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-401dc5e0-9aab-4bdf-9d9d-bb4524858c12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-401dc5e0-9aab-4bdf-9d9d-bb4524858c12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

