### PR TITLE
Fix custom Toa mask double-render and story-only mask rules

### DIFF
--- a/src/components/CharacterScene/DiminishedMatoranModel.tsx
+++ b/src/components/CharacterScene/DiminishedMatoranModel.tsx
@@ -65,9 +65,8 @@ export function DiminishedMatoranModel({
     weathered: DIMINISHED_WEATHERED,
   });
 
-  const maskTarget = matoran.maskOverride ?? matoran.mask;
   const glowColor = matoran.colors.eyes;
-  useMask(nodes.Masks, maskTarget, matoran, glowColor);
+  useMask(nodes.Masks, matoran, glowColor);
 
   return (
     <group ref={group} dispose={null}>

--- a/src/components/CharacterScene/Mata/GaliMataModel.tsx
+++ b/src/components/CharacterScene/Mata/GaliMataModel.tsx
@@ -55,9 +55,8 @@ export const GaliMataModel = forwardRef<
     weathered: GALI_WEATHERED,
   });
 
-  const maskTarget = matoran.maskOverride || matoran.mask;
   const glowColor = matoran.colors.eyes;
-  useMask(nodes.Masks, maskTarget, matoran, glowColor, matoran.maskPowerActive);
+  useMask(nodes.Masks, matoran, glowColor, matoran.maskPowerActive);
 
   return (
     <group ref={group} dispose={null}>

--- a/src/components/CharacterScene/Mata/KopakaMataModel.tsx
+++ b/src/components/CharacterScene/Mata/KopakaMataModel.tsx
@@ -54,9 +54,8 @@ export const KopakaMataModel = forwardRef<
     weathered: KOPAKA_WEATHERED,
   });
 
-  const maskTarget = matoran.maskOverride || matoran.mask;
   const glowColor = matoran.colors.eyes;
-  useMask(nodes.Masks, maskTarget, matoran, glowColor, matoran.maskPowerActive);
+  useMask(nodes.Masks, matoran, glowColor, matoran.maskPowerActive);
 
   return (
     <group ref={group} dispose={null}>

--- a/src/components/CharacterScene/Mata/LewaMataModel.tsx
+++ b/src/components/CharacterScene/Mata/LewaMataModel.tsx
@@ -54,9 +54,8 @@ export const LewaMataModel = forwardRef<
     weathered: LEWA_WEATHERED,
   });
 
-  const maskTarget = matoran.maskOverride || matoran.mask;
   const glowColor = matoran.colors.eyes;
-  useMask(nodes.Masks, maskTarget, matoran, glowColor, matoran.maskPowerActive);
+  useMask(nodes.Masks, matoran, glowColor, matoran.maskPowerActive);
 
   return (
     <group ref={group} dispose={null}>

--- a/src/components/CharacterScene/Mata/OnuaMataModel.tsx
+++ b/src/components/CharacterScene/Mata/OnuaMataModel.tsx
@@ -54,9 +54,8 @@ export const OnuaMataModel = forwardRef<
     weathered: ONUA_WEATHERED,
   });
 
-  const maskTarget = matoran.maskOverride || matoran.mask;
   const glowColor = matoran.colors.eyes;
-  useMask(nodes.Masks, maskTarget, matoran, glowColor, matoran.maskPowerActive);
+  useMask(nodes.Masks, matoran, glowColor, matoran.maskPowerActive);
 
   return (
     <group ref={group} dispose={null}>

--- a/src/components/CharacterScene/Mata/PohatuMataModel.tsx
+++ b/src/components/CharacterScene/Mata/PohatuMataModel.tsx
@@ -51,9 +51,8 @@ export const PohatuMataModel = forwardRef<
     weathered: POHATU_WEATHERED,
   });
 
-  const maskTarget = matoran.maskOverride || matoran.mask;
   const glowColor = matoran.colors.eyes;
-  useMask(nodes.Masks, maskTarget, matoran, glowColor, matoran.maskPowerActive);
+  useMask(nodes.Masks, matoran, glowColor, matoran.maskPowerActive);
 
   return (
     <group ref={group} dispose={null}>

--- a/src/components/CharacterScene/Mata/TahuMataModel.tsx
+++ b/src/components/CharacterScene/Mata/TahuMataModel.tsx
@@ -55,9 +55,8 @@ export const TahuMataModel = forwardRef<
     weathered: TAHU_WEATHERED,
   });
 
-  const maskTarget = matoran.maskOverride || matoran.mask;
   const glowColor = matoran.colors.eyes;
-  useMask(nodes.Masks, maskTarget, matoran, glowColor, matoran.maskPowerActive);
+  useMask(nodes.Masks, matoran, glowColor, matoran.maskPowerActive);
 
   return (
     <group ref={group} dispose={null}>

--- a/src/components/CharacterScene/RebuiltMatoranModel.tsx
+++ b/src/components/CharacterScene/RebuiltMatoranModel.tsx
@@ -80,9 +80,8 @@ export function RebuiltMatoranModel({
     weathered: REBUILT_WEATHERED,
   });
 
-  const maskTarget = matoran.maskOverride || matoran.mask;
   const glowColor = matoran.colors.eyes;
-  useMask(nodes.Masks, maskTarget, matoran, glowColor);
+  useMask(nodes.Masks, matoran, glowColor);
 
   return (
     <group ref={group} dispose={null}>

--- a/src/game/maskColor.spec.ts
+++ b/src/game/maskColor.spec.ts
@@ -39,6 +39,15 @@ describe('maskColor', () => {
     test('returns base mask color when no quests completed', () => {
       expect(getEffectiveMataMaskColor(toaMata, [])).toBe(LegoColor.Red);
     });
+
+    test('does not apply gold mask tint to custom Toa Mata', () => {
+      const custom: BaseMatoran & RecruitedCharacterData = {
+        ...toaMata,
+        id: 'custom_0',
+        mask: Mask.Huna,
+      };
+      expect(getEffectiveMataMaskColor(custom, ['mnog_kini_nui_arrival'])).toBe(LegoColor.Red);
+    });
   });
 
   describe('getEffectiveNuvaMaskColor', () => {

--- a/src/game/maskColor.ts
+++ b/src/game/maskColor.ts
@@ -1,4 +1,4 @@
-import { BaseMatoran, MatoranStage } from '../types/Matoran';
+import { BaseMatoran, isCustomCharacterId, MatoranStage } from '../types/Matoran';
 import { LegoColor } from '../types/Colors';
 import { isNuvaSymbolsSequestered } from './nuvaSymbols';
 
@@ -10,25 +10,29 @@ function isGoldMaskQuestCompleted(completedQuests: string[]): boolean {
 
 /**
  * Effective mask color for Toa Mata, based on user override and game state.
- * Gold mask override when Kini-Nui quests are completed.
+ * Gold mask override when Kini-Nui quests are completed (canon Toa only).
  */
 export function getEffectiveMataMaskColor(
   matoran: BaseMatoran & { maskOverride?: string },
   completedQuests: string[]
 ): string {
-  if (isGoldMaskQuestCompleted(completedQuests)) return LegoColor.PearlGold;
+  if (!isCustomCharacterId(matoran.id) && isGoldMaskQuestCompleted(completedQuests)) {
+    return LegoColor.PearlGold;
+  }
   return matoran.colors.mask;
 }
 
 /**
  * Effective mask color for Toa Nuva, based on user override and game state.
- * Light gray when nuva symbols are sequestered.
+ * Light gray when nuva symbols are sequestered (canon Toa only).
  */
 export function getEffectiveNuvaMaskColor(
   matoran: BaseMatoran & { maskOverride?: string },
   completedQuests: string[]
 ): string {
-  if (isNuvaSymbolsSequestered(completedQuests)) return LegoColor.LightGray;
+  if (!isCustomCharacterId(matoran.id) && isNuvaSymbolsSequestered(completedQuests)) {
+    return LegoColor.LightGray;
+  }
   return matoran.colors.mask;
 }
 

--- a/src/hooks/ensureMaskSlotPlaceholderHidden.ts
+++ b/src/hooks/ensureMaskSlotPlaceholderHidden.ts
@@ -7,10 +7,11 @@ function isTintableMat(mat: unknown): mat is MeshPhysicalMaterial | MeshStandard
 }
 
 /**
- * Mata / Matoran character GLBs parent mask clones under a node named "Masks" that
- * often still includes the mesh author's default kanohi. Hide that placeholder mesh
- * so only masks.glb clones render. Without this, equipping a mask that differs from
- * the default (e.g. custom Toa on a borrowed Mata rig) shows two overlapping masks.
+ * Mata / Matoran GLBs parent mask clones under a node named `Masks` that also carries
+ * a tiny placeholder solid (e.g. a small cube) from the mesh author — not a second
+ * Kanohi, and not meaningfully visible with current mask assets. We still make that
+ * mesh fully transparent so it cannot z-fight or clip through the real mask from
+ * `masks.glb` if transforms or materials change.
  *
  * Uses a WeakSet so we only replace materials once per shared cached `nodes.Masks`
  * instance from useGLTF.

--- a/src/hooks/ensureMaskSlotPlaceholderHidden.ts
+++ b/src/hooks/ensureMaskSlotPlaceholderHidden.ts
@@ -1,0 +1,34 @@
+import { Mesh, MeshPhysicalMaterial, MeshStandardMaterial, Object3D } from 'three';
+
+const maskSlotPlaceholdersHidden = new WeakSet<Object3D>();
+
+function isTintableMat(mat: unknown): mat is MeshPhysicalMaterial | MeshStandardMaterial {
+  return mat instanceof MeshPhysicalMaterial || mat instanceof MeshStandardMaterial;
+}
+
+/**
+ * Mata / Matoran character GLBs parent mask clones under a node named "Masks" that
+ * often still includes the mesh author's default kanohi. Hide that placeholder mesh
+ * so only masks.glb clones render. Without this, equipping a mask that differs from
+ * the default (e.g. custom Toa on a borrowed Mata rig) shows two overlapping masks.
+ *
+ * Uses a WeakSet so we only replace materials once per shared cached `nodes.Masks`
+ * instance from useGLTF.
+ */
+export function ensureMaskSlotPlaceholderHidden(masksParent: Object3D | undefined): void {
+  if (!masksParent || maskSlotPlaceholdersHidden.has(masksParent)) return;
+  const mesh = masksParent as Mesh;
+  if (!mesh.isMesh || !mesh.material) return;
+  const raw = mesh.material;
+  const mats = Array.isArray(raw) ? raw : [raw];
+  const next = mats.map((m) => {
+    if (!isTintableMat(m)) return m;
+    const c = m.clone();
+    c.transparent = true;
+    c.opacity = 0;
+    c.depthWrite = false;
+    return c;
+  });
+  mesh.material = Array.isArray(raw) ? next : next[0];
+  maskSlotPlaceholdersHidden.add(masksParent);
+}

--- a/src/hooks/useMask.ts
+++ b/src/hooks/useMask.ts
@@ -5,12 +5,14 @@ import { useGame } from '../context/Game';
 import { useSettings } from '../context/useSettings';
 import { shouldEnableShadows } from '../utils/testMode';
 import { getEffectiveMataMaskColor } from '../game/maskColor';
+import { masksCollected } from '../services/matoranUtils';
 import { BaseMatoran, Mask, MatoranStage } from '../types/Matoran';
 import {
   createMaskTransitionState,
   startMaskTransition,
   useMaskTransitionFrame,
 } from './maskTransition';
+import { ensureMaskSlotPlaceholderHidden } from './ensureMaskSlotPlaceholderHidden';
 
 const MASKS_GLB_PATH = import.meta.env.BASE_URL + 'masks.glb';
 
@@ -87,8 +89,7 @@ function applyMaskColors(
  * The first mask shown on load appears immediately with no transition.
  *
  * @param masksParent - The Object3D to parent the mask to (e.g. `nodes.Masks`)
- * @param maskName    - The name of the mask mesh in masks.glb (must match the Mask enum value)
- * @param matoran     - Character data (Mata/Diminished) for mask color derivation
+ * @param matoran     - Character data (Mata/Diminished) for mask selection and color
  * @param glowColor   - Optional color for emissive "glow" materials (e.g. lens glow matching eye color).
  *                      When provided, materials whose names include "glow" (case-insensitive) will use
  *                      this color for both their base color and emissive color instead of maskColor.
@@ -96,7 +97,6 @@ function applyMaskColors(
  */
 export function useMask(
   masksParent: Object3D | undefined,
-  maskName: string,
   matoran: BaseMatoran & { maskOverride?: string },
   glowColor?: string,
   maskPowerActive?: boolean
@@ -106,6 +106,16 @@ export function useMask(
   const { completedQuests } = useGame();
   const { shadowsEnabled } = useSettings();
   const effectiveShadows = shadowsEnabled && shouldEnableShadows();
+
+  const collected = useMemo(
+    () => masksCollected(matoran, completedQuests),
+    [matoran, completedQuests]
+  );
+  const maskName = useMemo(() => {
+    const effectiveMask = collected.includes(matoran.mask) ? matoran.mask : collected[0];
+    const override = matoran.maskOverride;
+    return override && collected.includes(override) ? override : effectiveMask;
+  }, [collected, matoran.mask, matoran.maskOverride]);
 
   const maskColor =
     matoran.stage === MatoranStage.ToaMata
@@ -130,6 +140,8 @@ export function useMask(
   // Clone the mask and attach to parent; animate transitions between masks
   useEffect(() => {
     if (!masksNodes || !masksParent) return;
+
+    ensureMaskSlotPlaceholderHidden(masksParent);
 
     const source = masksNodes[maskName];
     if (!source) {

--- a/src/hooks/useMask.ts
+++ b/src/hooks/useMask.ts
@@ -97,7 +97,7 @@ function applyMaskColors(
  */
 export function useMask(
   masksParent: Object3D | undefined,
-  matoran: BaseMatoran & { maskOverride?: string },
+  matoran: BaseMatoran & { maskOverride?: Mask },
   glowColor?: string,
   maskPowerActive?: boolean
 ) {

--- a/src/hooks/useNuvaMask.ts
+++ b/src/hooks/useNuvaMask.ts
@@ -11,6 +11,7 @@ import {
   startMaskTransition,
   useMaskTransitionFrame,
 } from './maskTransition';
+import { ensureMaskSlotPlaceholderHidden } from './ensureMaskSlotPlaceholderHidden';
 import { masksCollected } from '../services/matoranUtils';
 
 const NUVA_MASKS_GLB_PATH = import.meta.env.BASE_URL + 'Toa_Nuva/masks.glb';
@@ -121,6 +122,8 @@ export function useNuvaMask(
 
   useEffect(() => {
     if (!masksNodes || !masksParent) return;
+
+    ensureMaskSlotPlaceholderHidden(masksParent);
 
     const source = masksNodes[maskNodeName];
     if (!source) {

--- a/src/services/matoranUtils.spec.ts
+++ b/src/services/matoranUtils.spec.ts
@@ -324,6 +324,18 @@ describe('matoranUtils', () => {
         expect(masks).toEqual([Mask.HauNuva]);
       });
 
+      test('custom Toa Nuva only has dex mask even after Kanohi Nuva hunt', () => {
+        const custom: BaseMatoran = {
+          colors: MOCK_COLORS,
+          element: ElementTribe.Fire,
+          id: 'custom_0',
+          mask: Mask.HauNuva,
+          name: 'Custom',
+          stage: MatoranStage.ToaNuva,
+        };
+        expect(masksCollected(custom, ['tales_kanohi_nuva_hunt'])).toEqual([Mask.HauNuva]);
+      });
+
       test('returns only dex mask even when final collection quest is completed', () => {
         const masks = masksCollected(mockToaNuva, ['maskhunt_final_collection']);
         expect(masks).toEqual([Mask.HauNuva]);

--- a/src/services/matoranUtils.ts
+++ b/src/services/matoranUtils.ts
@@ -1,4 +1,10 @@
-import { BaseMatoran, ListedCharacterData, Mask, RecruitedCharacterData } from '../types/Matoran';
+import {
+  BaseMatoran,
+  isCustomCharacterId,
+  ListedCharacterData,
+  Mask,
+  RecruitedCharacterData,
+} from '../types/Matoran';
 import { MatoranJob } from '../types/Jobs';
 import { JOB_DETAILS } from '../data/jobs';
 import { getProductivityModifier } from '../game/Jobs';
@@ -43,6 +49,10 @@ export function masksCollected(
       return [Mask.HauNuvaInfected];
     }
 
+    if (isCustomCharacterId(matoran.id)) {
+      return [matoran.mask];
+    }
+
     let masks: Mask[] = [matoran.mask];
     if (matoran.id === 'Toa_Tahu_Nuva' && storyProgress.includes('bohrok_kal_reconstruction')) {
       masks.push(Mask.Vahi);
@@ -55,6 +65,9 @@ export function masksCollected(
     }
     return masks;
   } else if (isToaMata(matoran)) {
+    if (isCustomCharacterId(matoran.id)) {
+      return [matoran.mask];
+    }
     const masks: Mask[] = [];
     if (storyProgress.includes('maskhunt_final_collection')) {
       return FULL_MASK_SET;

--- a/src/services/matoranUtils.ts
+++ b/src/services/matoranUtils.ts
@@ -41,6 +41,10 @@ export function masksCollected(
   matoran: BaseMatoran,
   storyProgress: GameState['completedQuests']
 ): Mask[] {
+  if (isCustomCharacterId(matoran.id)) {
+    return [matoran.mask];
+  }
+
   if (isToaNuva(matoran)) {
     if (matoran.id === 'Takanuva') {
       return [Mask.Avohkii];
@@ -49,9 +53,6 @@ export function masksCollected(
       return [Mask.HauNuvaInfected];
     }
 
-    if (isCustomCharacterId(matoran.id)) {
-      return [matoran.mask];
-    }
 
     let masks: Mask[] = [matoran.mask];
     if (matoran.id === 'Toa_Tahu_Nuva' && storyProgress.includes('bohrok_kal_reconstruction')) {
@@ -65,9 +66,6 @@ export function masksCollected(
     }
     return masks;
   } else if (isToaMata(matoran)) {
-    if (isCustomCharacterId(matoran.id)) {
-      return [matoran.mask];
-    }
     const masks: Mask[] = [];
     if (storyProgress.includes('maskhunt_final_collection')) {
       return FULL_MASK_SET;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Custom Toa were picking up **canon mask hunt / Nuva hunt inventory** and **global story mask colors** (gold Mata tint, gray Nuva symbols), and the Mata/Matoran GLBs keep a **default kanohi mesh on the `Masks` node** while `useMask` also parents a clone from `masks.glb`. When the equipped mask differs from that default (e.g. custom character on the Tahu rig with a Huna), both meshes showed through.

## Changes

- **`masksCollected`**: For `custom_*` ids at Toa Mata or Toa Nuva, return only the character’s dex mask so the inventory UI and runtime selection cannot grant the full canon swap set.
- **`useMask`**: Resolve the active mask the same way as Nuva (`masksCollected` + valid `maskOverride`), and call **`ensureMaskSlotPlaceholderHidden`** so the GLB placeholder on `Masks` is not drawn under the dynamic mask.
- **`useNuvaMask`**: Same placeholder hide for Nuva rigs (consistent if a custom ever uses a Nuva model path).
- **`maskColor`**: Pearl gold (Kini-Nui) and light gray (symbol sequester) tints apply only to **non-custom** characters.
- **Tests**: `maskColor.spec` and `matoranUtils.spec` cover custom-id behavior.

## Notes

Existing saves may still store a stale `maskOverride` on a custom character; it is now ignored unless it matches the allowed set (dex mask only), so the 3D view falls back to the correct single mask without requiring a migration.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d40d5876-ac03-46ad-bdb9-61fa0910aaf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d40d5876-ac03-46ad-bdb9-61fa0910aaf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

