### PR TITLE
Fix character list/detail scroll position

### DIFF
--- a/src/pages/CharacterDetail/index.tsx
+++ b/src/pages/CharacterDetail/index.tsx
@@ -6,7 +6,11 @@ import { isTestMode } from '../../utils/testMode';
 import './index.scss';
 import { CharacterScene } from '../../components/CharacterScene';
 import { ElementTag } from '../../components/ElementTag';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import {
+  rememberCharactersReturnScrollId,
+  scrollMainContentToTop,
+} from '../../utils/mainContentScroll';
 import { useSceneCanvas } from '../../hooks/useSceneCanvas';
 import { QUESTS } from '../../data/quests';
 import { getRecruitedMatoran, masksCollected } from '../../services/matoranUtils';
@@ -49,6 +53,12 @@ export const CharacterDetail: React.FC = () => {
   );
 
   const [activeTab, setActiveTab] = useState('stats');
+
+  useLayoutEffect(() => {
+    if (!id) return;
+    rememberCharactersReturnScrollId(String(id));
+    scrollMainContentToTop();
+  }, [id]);
 
   const tabs = useMemo(() => {
     const base = ['stats'];

--- a/src/pages/CharacterInventory/index.tsx
+++ b/src/pages/CharacterInventory/index.tsx
@@ -14,7 +14,11 @@ import { useGame } from '../../context/Game';
 import { QUESTS } from '../../data/quests';
 import { getEffectiveMatoran } from '../../services/matoranUtils';
 import { isBohrokOrKal, isMatoran, isToa } from '../../game/matoranStage';
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo, useState, useCallback, useLayoutEffect } from 'react';
+import {
+  consumeCharactersReturnScrollId,
+  scrollMainContentElementIntoView,
+} from '../../utils/mainContentScroll';
 import { Tabs } from '../../components/Tabs';
 import { CHARACTER_DEX } from '../../data/dex/index';
 import {
@@ -111,6 +115,18 @@ export const CharacterInventory: React.FC = () => {
     });
   }, [recruitedCharacters, effectiveTab]);
 
+  useLayoutEffect(() => {
+    const returnScrollId = consumeCharactersReturnScrollId();
+    if (!returnScrollId) return;
+
+    const card = document.querySelector<HTMLElement>(
+      `[data-character-id="${CSS.escape(returnScrollId)}"]`
+    );
+    if (!card) return;
+
+    scrollMainContentElementIntoView(card);
+  }, [effectiveTab, characters]);
+
   const collectedKraata = useMemo(() => {
     const groups: { power: KraataPower; stage: number; name: string; count: number }[] = [];
     for (const [power, stages] of Object.entries(kraataCollection)) {
@@ -154,6 +170,7 @@ export const CharacterInventory: React.FC = () => {
             return (
               <Link key={matoran.id} to={`/characters/${matoran.id}`}>
                 <motion.div
+                  data-character-id={matoran.id}
                   className={`character-card element-${effective.element}`}
                   layoutId={shouldReduceMotion ? undefined : `character-${matoran.id}`}
                   layout

--- a/src/utils/mainContentScroll.spec.ts
+++ b/src/utils/mainContentScroll.spec.ts
@@ -34,12 +34,40 @@ describe('mainContentScroll', () => {
   it('scrolls a target element into view within main content', () => {
     const main = document.querySelector<HTMLElement>('.main-content')!;
     const target = document.getElementById('target')!;
+
+    // jsdom does not compute layout; mock rects so scroll math is exercised.
+    const mainRect = {
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 300,
+      width: 300,
+      height: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+    const targetRect = {
+      top: 250,
+      left: 0,
+      bottom: 270,
+      right: 100,
+      width: 100,
+      height: 20,
+      x: 0,
+      y: 250,
+      toJSON: () => ({}),
+    } as DOMRect;
+
+    jest.spyOn(main, 'getBoundingClientRect').mockReturnValue(mainRect);
+    jest.spyOn(target, 'getBoundingClientRect').mockReturnValue(targetRect);
+    Object.defineProperty(main, 'clientHeight', { configurable: true, value: 100 });
+
+    main.scrollTop = 0;
     scrollMainContentElementIntoView(target);
-    expect(main.scrollTop).toBeGreaterThan(0);
-    const mainRect = main.getBoundingClientRect();
-    const targetRect = target.getBoundingClientRect();
-    expect(targetRect.top).toBeGreaterThanOrEqual(mainRect.top);
-    expect(targetRect.bottom).toBeLessThanOrEqual(mainRect.bottom + 1);
+
+    // Target bottom (270) is below visible area (100) → scroll to 170.
+    expect(main.scrollTop).toBe(170);
   });
 
   it('remembers and consumes return scroll id', () => {

--- a/src/utils/mainContentScroll.spec.ts
+++ b/src/utils/mainContentScroll.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  CHARACTERS_RETURN_SCROLL_ID_KEY,
+  consumeCharactersReturnScrollId,
+  rememberCharactersReturnScrollId,
+  scrollMainContentElementIntoView,
+  scrollMainContentToTop,
+} from './mainContentScroll';
+
+describe('mainContentScroll', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <main class="main-content" style="height: 100px; overflow: auto;">
+        <div id="target" style="height: 20px; margin-top: 200px;">target</div>
+      </main>
+    `;
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    sessionStorage.clear();
+  });
+
+  it('scrolls main content to top', () => {
+    const main = document.querySelector<HTMLElement>('.main-content')!;
+    main.scrollTop = 120;
+    scrollMainContentToTop();
+    expect(main.scrollTop).toBe(0);
+  });
+
+  it('scrolls a target element into view within main content', () => {
+    const main = document.querySelector<HTMLElement>('.main-content')!;
+    const target = document.getElementById('target')!;
+    scrollMainContentElementIntoView(target);
+    expect(main.scrollTop).toBeGreaterThan(0);
+    const mainRect = main.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    expect(targetRect.top).toBeGreaterThanOrEqual(mainRect.top);
+    expect(targetRect.bottom).toBeLessThanOrEqual(mainRect.bottom + 1);
+  });
+
+  it('remembers and consumes return scroll id', () => {
+    rememberCharactersReturnScrollId('Jala');
+    expect(sessionStorage.getItem(CHARACTERS_RETURN_SCROLL_ID_KEY)).toBe('Jala');
+    expect(consumeCharactersReturnScrollId()).toBe('Jala');
+    expect(sessionStorage.getItem(CHARACTERS_RETURN_SCROLL_ID_KEY)).toBeNull();
+  });
+});

--- a/src/utils/mainContentScroll.spec.ts
+++ b/src/utils/mainContentScroll.spec.ts
@@ -37,26 +37,26 @@ describe('mainContentScroll', () => {
 
     // jsdom does not compute layout; mock rects so scroll math is exercised.
     const mainRect = {
-      top: 0,
-      left: 0,
       bottom: 100,
-      right: 300,
-      width: 300,
       height: 100,
+      left: 0,
+      right: 300,
+      toJSON: () => ({}),
+      top: 0,
+      width: 300,
       x: 0,
       y: 0,
-      toJSON: () => ({}),
     } as DOMRect;
     const targetRect = {
-      top: 250,
-      left: 0,
       bottom: 270,
-      right: 100,
-      width: 100,
       height: 20,
+      left: 0,
+      right: 100,
+      toJSON: () => ({}),
+      top: 250,
+      width: 100,
       x: 0,
       y: 250,
-      toJSON: () => ({}),
     } as DOMRect;
 
     jest.spyOn(main, 'getBoundingClientRect').mockReturnValue(mainRect);

--- a/src/utils/mainContentScroll.ts
+++ b/src/utils/mainContentScroll.ts
@@ -1,0 +1,59 @@
+export const CHARACTERS_RETURN_SCROLL_ID_KEY = 'characters-return-scroll-id';
+
+const MAIN_CONTENT_SELECTOR = '.main-content';
+
+export function getMainContentElement(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(MAIN_CONTENT_SELECTOR);
+}
+
+export function scrollMainContentToTop(): void {
+  const main = getMainContentElement();
+  if (!main) return;
+  main.scrollTop = 0;
+}
+
+export function scrollMainContentElementIntoView(
+  element: Element,
+  options: ScrollIntoViewOptions = { block: 'nearest' }
+): void {
+  const main = getMainContentElement();
+  if (!main) {
+    element.scrollIntoView(options);
+    return;
+  }
+
+  const mainRect = main.getBoundingClientRect();
+  const elementRect = element.getBoundingClientRect();
+  const offsetTop = elementRect.top - mainRect.top + main.scrollTop;
+  const offsetBottom = elementRect.bottom - mainRect.top + main.scrollTop;
+
+  if (offsetTop < main.scrollTop) {
+    main.scrollTop = offsetTop;
+    return;
+  }
+
+  const visibleBottom = main.scrollTop + main.clientHeight;
+  if (offsetBottom > visibleBottom) {
+    main.scrollTop = offsetBottom - main.clientHeight;
+  }
+}
+
+export function rememberCharactersReturnScrollId(characterId: string): void {
+  try {
+    sessionStorage.setItem(CHARACTERS_RETURN_SCROLL_ID_KEY, characterId);
+  } catch {
+    /* ignore storage errors */
+  }
+}
+
+export function consumeCharactersReturnScrollId(): string | null {
+  try {
+    const id = sessionStorage.getItem(CHARACTERS_RETURN_SCROLL_ID_KEY);
+    if (id) {
+      sessionStorage.removeItem(CHARACTERS_RETURN_SCROLL_ID_KEY);
+    }
+    return id;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The app scrolls inside `.main-content`, which persists across route changes. That caused the character inventory scroll position to carry over into character detail, which is confusing when the detail page layout is different.

This change:

- **Resets scroll to top** when opening a character detail page
- **Scrolls the last-viewed character card into view** when returning to the inventory (browser back, Characters nav, etc.)

## Implementation

- Added `src/utils/mainContentScroll.ts` with helpers that scroll the `.main-content` container (not `window`)
- Character detail remembers the active character id in `sessionStorage` and scrolls to top on mount
- Character inventory consumes that id on mount and scrolls the matching `[data-character-id]` card into view

## Testing

- `yarn lint` — pass
- `yarn build` — pass
- Unit tests added in `mainContentScroll.spec.ts` (Jest config in this environment could not be executed due to existing `jest.config.ts` / ESM issue)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c5b0077-81c8-4f3e-a539-2ab7bbcb5b9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c5b0077-81c8-4f3e-a539-2ab7bbcb5b9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

