### PR TITLE
Fix seeded wear noise texture generation for deterministic renders

### DIFF
--- a/src/components/CharacterScene/WornPlasticMaterial.ts
+++ b/src/components/CharacterScene/WornPlasticMaterial.ts
@@ -11,13 +11,15 @@ import {
   ColorRepresentation,
   DataTexture,
   DoubleSide,
-  LinearFilter,
   Mesh,
   Object3D,
-  RepeatWrapping,
   ShaderMaterial,
   Vector3,
 } from 'three';
+import {
+  createTileableNoiseTexture,
+  DEFAULT_WEAR_NOISE_TEXTURE_SEED,
+} from '../../utils/tileableNoiseTexture';
 
 export type WornPlasticOptions = {
   color?: ColorRepresentation;
@@ -34,49 +36,17 @@ export type WornPlasticOptions = {
   ambient?: number;
   /** UV scale for noise map: lower = bigger patches (e.g. 0.3–0.5). */
   noiseScaleUV?: number;
+  /** Seed for the tileable wear noise texture; fixed default keeps renders stable. */
+  noiseTextureSeed?: number;
 };
 
-const NOISE_SIZE = 128;
+const noiseMapCache = new Map<number, DataTexture>();
 
-function createTileableNoiseTexture(): DataTexture {
-  const size = NOISE_SIZE;
-  const grid: number[] = [];
-  for (let i = 0; i < size * size; i++) grid.push(Math.random());
-  const sample = (ix: number, iy: number) => grid[(iy % size) * size + (ix % size)];
-  const data = new Uint8Array(size * size * 4);
-  for (let j = 0; j < size; j++) {
-    for (let i = 0; i < size; i++) {
-      const x = i + 0.5;
-      const y = j + 0.5;
-      const i0 = Math.floor(x) % size;
-      const i1 = (i0 + 1) % size;
-      const j0 = Math.floor(y) % size;
-      const j1 = (j0 + 1) % size;
-      const fx = x - Math.floor(x);
-      const fy = y - Math.floor(y);
-      const v =
-        (1 - fx) * (1 - fy) * sample(i0, j0) +
-        fx * (1 - fy) * sample(i1, j0) +
-        (1 - fx) * fy * sample(i0, j1) +
-        fx * fy * sample(i1, j1);
-      const idx = (j * size + i) * 4;
-      const byte = Math.floor(v * 255);
-      data[idx] = data[idx + 1] = data[idx + 2] = byte;
-      data[idx + 3] = 255;
-    }
+function getNoiseMap(seed: number = DEFAULT_WEAR_NOISE_TEXTURE_SEED): DataTexture {
+  if (!noiseMapCache.has(seed)) {
+    noiseMapCache.set(seed, createTileableNoiseTexture(seed));
   }
-  const tex = new DataTexture(data, size, size);
-  tex.wrapS = tex.wrapT = RepeatWrapping;
-  tex.minFilter = tex.magFilter = LinearFilter;
-  tex.needsUpdate = true;
-  return tex;
-}
-
-let sharedNoiseMap: DataTexture | null = null;
-
-function getNoiseMap(): DataTexture {
-  if (!sharedNoiseMap) sharedNoiseMap = createTileableNoiseTexture();
-  return sharedNoiseMap;
+  return noiseMapCache.get(seed)!;
 }
 
 const WORN_VERTEX = /* glsl */ `
@@ -229,7 +199,9 @@ function makeWornUniforms(
     },
     uLightDirection2: { value: DEFAULT_LIGHT_DIR2.clone() },
     uMetalness: { value: opts.metalness ?? 0.05 },
-    uNoiseMap: { value: getNoiseMap() },
+    uNoiseMap: {
+      value: getNoiseMap(opts.noiseTextureSeed ?? DEFAULT_WEAR_NOISE_TEXTURE_SEED),
+    },
     uNoiseScale: { value: opts.noiseScale ?? 14.0 },
     uNoiseScaleUV: { value: opts.noiseScaleUV ?? 0.1 },
     uOpacity: { value: 1 },

--- a/src/utils/seededRandom.ts
+++ b/src/utils/seededRandom.ts
@@ -1,0 +1,14 @@
+/**
+ * Mulberry32 PRNG — deterministic pseudo-random floats in [0, 1).
+ * Use for procedural assets (e.g. wear noise textures) that must not change on reload.
+ */
+export function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/src/utils/tileableNoiseTexture.spec.ts
+++ b/src/utils/tileableNoiseTexture.spec.ts
@@ -1,0 +1,22 @@
+import {
+  createTileableNoiseTexture,
+  DEFAULT_WEAR_NOISE_TEXTURE_SEED,
+} from './tileableNoiseTexture';
+
+function texelBytes(tex: ReturnType<typeof createTileableNoiseTexture>): number[] {
+  return Array.from(tex.image.data);
+}
+
+describe('createTileableNoiseTexture', () => {
+  it('produces identical texel data for the same seed', () => {
+    const a = createTileableNoiseTexture(DEFAULT_WEAR_NOISE_TEXTURE_SEED);
+    const b = createTileableNoiseTexture(DEFAULT_WEAR_NOISE_TEXTURE_SEED);
+    expect(texelBytes(a)).toEqual(texelBytes(b));
+  });
+
+  it('produces different texel data for different seeds', () => {
+    const a = createTileableNoiseTexture(1);
+    const b = createTileableNoiseTexture(2);
+    expect(texelBytes(a)).not.toEqual(texelBytes(b));
+  });
+});

--- a/src/utils/tileableNoiseTexture.ts
+++ b/src/utils/tileableNoiseTexture.ts
@@ -1,0 +1,48 @@
+import { DataTexture, LinearFilter, RepeatWrapping } from 'three';
+import { createSeededRandom } from './seededRandom';
+
+/** Fixed seed so wear / weathered noise textures are stable across reloads and in tests. */
+export const DEFAULT_WEAR_NOISE_TEXTURE_SEED = 0x8f3c2a1b;
+
+const NOISE_SIZE = 128;
+
+/**
+ * Builds a tileable grayscale noise `DataTexture` from a seeded PRNG grid.
+ * Same seed always produces identical texel data.
+ */
+export function createTileableNoiseTexture(
+  seed: number = DEFAULT_WEAR_NOISE_TEXTURE_SEED
+): DataTexture {
+  const size = NOISE_SIZE;
+  const next = createSeededRandom(seed);
+  const grid: number[] = [];
+  for (let i = 0; i < size * size; i++) grid.push(next());
+  const sample = (ix: number, iy: number) => grid[(iy % size) * size + (ix % size)];
+  const data = new Uint8Array(size * size * 4);
+  for (let j = 0; j < size; j++) {
+    for (let i = 0; i < size; i++) {
+      const x = i + 0.5;
+      const y = j + 0.5;
+      const i0 = Math.floor(x) % size;
+      const i1 = (i0 + 1) % size;
+      const j0 = Math.floor(y) % size;
+      const j1 = (j0 + 1) % size;
+      const fx = x - Math.floor(x);
+      const fy = y - Math.floor(y);
+      const v =
+        (1 - fx) * (1 - fy) * sample(i0, j0) +
+        fx * (1 - fy) * sample(i1, j0) +
+        (1 - fx) * fy * sample(i0, j1) +
+        fx * fy * sample(i1, j1);
+      const idx = (j * size + i) * 4;
+      const byte = Math.floor(v * 255);
+      data[idx] = data[idx + 1] = data[idx + 2] = byte;
+      data[idx + 3] = 255;
+    }
+  }
+  const tex = new DataTexture(data, size, size);
+  tex.wrapS = tex.wrapT = RepeatWrapping;
+  tex.minFilter = tex.magFilter = LinearFilter;
+  tex.needsUpdate = true;
+  return tex;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wear/weathered procedural materials used `Math.random()` when building the shared tileable noise `DataTexture`, so the grime patch pattern changed on every browser reload. That made visual regression tests flaky and made wear look inconsistent between sessions.

This PR replaces `Math.random()` with a seeded mulberry32 PRNG and a fixed default seed (`DEFAULT_WEAR_NOISE_TEXTURE_SEED`), so the same seed always produces identical texel data.

## Changes

- Added `src/utils/seededRandom.ts` — small mulberry32 PRNG helper
- Added `src/utils/tileableNoiseTexture.ts` — shared, seedable tileable noise texture builder
- Updated `WornPlasticMaterial.ts` to use the seeded generator (optional `noiseTextureSeed` override)
- Added unit tests verifying same-seed determinism and different-seed variation

## Notes

`WeatheredMetalMaterial` (the active weathered-metal shader used on Toa, Bohrok, Rahkshi, etc.) was already deterministic — its grime comes from object-space FBM in the fragment shader with fixed offsets. The reload-time randomness was in the tileable noise texture path used by `WornPlasticMaterial`.

## Testing

- `yarn jest --ci tileableNoiseTexture` — pass
- `yarn lint` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4159170-a6d8-46c8-a3ff-1d33389d7af0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4159170-a6d8-46c8-a3ff-1d33389d7af0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

