### PR TITLE
docs: refresh roadmap and related documentation

### DIFF
--- a/AGENT_GUIDELINES.md
+++ b/AGENT_GUIDELINES.md
@@ -62,7 +62,7 @@ The game runs entirely in the browser. All game logic must support offline progr
 
 **NEVER** duplicate static data into runtime state.
 
-**NEVER** mutate objects in `CHARACTER_DEX`, `JOB_DETAILS`, `ITEM_DICTIONARY`, or other data dictionaries.
+**NEVER** mutate objects in `CHARACTER_DEX`, `JOB_DETAILS`, or other static data dictionaries.
 
 ---
 
@@ -145,7 +145,7 @@ Kraata are tracked separately from the generic inventory via `kraataCollection` 
 
 **MUST ENFORCE:**
 
-1. Only these fields are persisted (see `PartialGameState` / `useGamePersistence`): `version`, `protodermis`, `protodermisCap`, `collectedKrana`, `kraataCollection`, `rahkshi`, `recruitedCharacters`, `activeQuests`, `completedQuests`. (`buyableCharacters` is derived at runtime from `completedQuests` and `recruitedCharacters` via the recruitment registry.) Legacy saves may still contain an `inventory` key until migration runs; it is not part of the current save shape.
+1. Only these fields are persisted (see `PartialGameState` / `useGamePersistence`): `version`, `protodermis`, `protodermisCap`, `collectedKrana`, `kraataCollection`, `rahkshi`, `recruitedCharacters`, `customCharacters`, `activeQuests`, `completedQuests`. (`buyableCharacters` is derived at runtime from `completedQuests` and `recruitedCharacters` via the recruitment registry.) Legacy saves may still contain an `inventory` key until migration runs; it is not part of the current save shape.
 2. Battle state is NOT persisted (battles reset on page refresh)
 3. Save version must match `CURRENT_GAME_STATE_VERSION` or the save is rejected
 

--- a/ARCHITECTURE_ROADMAP.md
+++ b/ARCHITECTURE_ROADMAP.md
@@ -10,22 +10,16 @@ This document identifies technical debt, inconsistencies, and architectural impr
 
 ## Priority 2: Consistency Improvements (Low Risk)
 
-### 2.1 Standardize User Feedback Mechanism
+### 2.1 Standardize User Feedback Mechanism ✅ Implemented
 
-**Issue:** Mixed use of `alert()` and activity log for user feedback.
+**Status:** Resolved. No `alert()` calls remain in the codebase.
 
-**Current locations:**
+**Implementation:**
 
-- `src/services/matoranUtils.ts` - uses `alert()` for insufficient protodermis
-- `src/pages/Recruitment/index.tsx` - uses `alert()` for successful recruitment
+- Successful recruitment shows `RecruitmentCelebration` (animated modal with 3D character reveal and element-colored particles).
+- Insufficient protodermis disables the recruit button (`canRecruit` guard); `recruitMatoran` returns the prior state without side effects.
 
-**Recommendation:** Replace `alert()` calls with proper UI feedback (toast notifications or activity log).
-
-**Acceptance Criteria:**
-
-- No `alert()` calls remain in codebase
-- User feedback is visible and non-blocking
-- Feedback is consistent across all actions
+**Remaining gap (optional polish):** There is still no shared toast/activity-log system for other transient feedback (e.g. PWA update badge is the only toast-like UI). Consider a unified non-blocking feedback component if more surfaces need it.
 
 ---
 
@@ -49,11 +43,14 @@ This document identifies technical debt, inconsistencies, and architectural impr
 
 ### 3.1 Add Save Migration System
 
-**Issue:** Changing `CURRENT_GAME_STATE_VERSION` invalidates all saves with no migration path.
+**Issue:** Changing `CURRENT_GAME_STATE_VERSION` invalidates all saves when no version-step migration exists.
 
-**Current behavior:** Version mismatch → reject save → load `INITIAL_GAME_STATE`
+**Current behavior:**
 
-**Recommendation:** Implement migration functions for version upgrades.
+- Version mismatch → reject save → load `INITIAL_GAME_STATE`
+- Ad-hoc retrocompat in `loadGameState` (`src/services/gamePersistence.ts`) handles specific legacy shapes when the version still matches: `widgets` → `protodermis`, kraata in legacy `inventory` → `kraataCollection`, unrecognized job IDs cleared, and missing `customCharacters` / `collectedKrana` / `rahkshi` defaults filled in
+
+**Recommendation:** Add explicit per-version migration functions so `CURRENT_GAME_STATE_VERSION` bumps can upgrade older saves instead of discarding them.
 
 **Proposed approach:**
 
@@ -116,13 +113,13 @@ function detectQuestCycles(quests: Quest[]): string[] {
 
 **Issue:** Minimal test coverage, especially for pure game logic functions.
 
-**Current:** Tests exist for `combatUtils`, `Levelling`, `Jobs`, `Quests`, `BattleRewards`, `Krana`, `encounterVisibility`, and various hooks/services. Coverage is improved but not yet comprehensive.
+**Current:** Unit tests exist across `src/game/` (e.g. `Levelling`, `Jobs`, `Quests`, `BattleRewards`, `Krana`, `CharacterEvolution`, `masks`, `nuvaSymbols`, `ProtodermisConversion`, `encounterVisibility`, `customMataBuild`) and `src/services/` (e.g. `combatUtils`, `maskPowers`, `maskPowerCooldowns`, `battleSimulation`, `gamePersistence`, `matoranUtils`, `customCharacterShare`). E2E coverage includes recruitment, quests, cutscenes, custom characters, battle flow, and character detail. Coverage is substantially improved but not yet comprehensive (e.g. some mask powers like Ruru/Matatu remain untested in combat).
 
-**Recommendation:** Continue adding tests for critical game logic in `src/game/`:
+**Recommendation:** Continue adding tests for critical game logic and combat edge cases:
 
-- `Levelling.ts` - exp calculations
-- `Jobs.ts` - productivity modifiers, offline progress, reward rolling
-- `Quests.ts` - quest availability filtering
+- Remaining mask power implementations (`Ruru`, `Matatu`)
+- Quest prerequisite validation (see 3.2)
+- Integration paths for custom character share/recruit flows
 
 **Acceptance Criteria:**
 
@@ -134,60 +131,56 @@ function detectQuestCycles(quests: Quest[]): string[] {
 
 ## Priority 5: Code Quality (Low Risk)
 
-### 5.1 Remove Commented Code
+### 5.1 Remove Commented Code ✅ Resolved
 
-**Issue:** Commented code suggests incomplete features or abandoned approaches.
+**Status:** The previously noted commented-out combatant-stats block in `CharacterDetail` has been removed. No other significant commented-out feature blocks are known in that file.
 
-**Locations:**
+**Acceptance Criteria (ongoing):**
 
-- `src/pages/CharacterDetail/index.tsx` (combatant stats in stats tab)
-
-**Recommendation:** Either implement the feature or remove the comment.
-
-**Acceptance Criteria:**
-
-- No commented-out code remains
-- If feature is needed, create a task to implement it properly
+- No commented-out code remains when discovered
+- If a feature is needed, create a task to implement it properly
 
 ---
 
-### 5.2 Populate Missing Item Metadata
+### 5.2 Item System (Removed — Deferred)
 
-**Issue:** Item fields like `rarity`, `value`, `description`, `icon` are mostly unpopulated.
+**Issue:** A generic item/inventory economy was removed from the game.
 
-**Current:** Items have been removed from the active economy. The `ITEM_DICTIONARY` and `GameItemId` enum still exist for future quest-item mechanics. Fields remain undefined in most entries.
+**Current:** `ITEM_DICTIONARY`, `GameItemId`, and the generic `inventory` save field are gone. Collectibles use dedicated state (`collectedKrana`, `kraataCollection`, mask collection via quest progress). Legacy saves with `inventory` are migrated into `kraataCollection` on load.
 
-**Recommendation:** Defer until items are reintroduced as quest items. At that point, either populate the fields or pare down the type.
+**Recommendation:** Defer reintroducing items until a concrete quest-item mechanic is designed. If reintroduced, define a minimal type from scratch rather than reviving the old dictionary.
 
-**Decision needed:**
+**Decision needed (when items return):**
 
-- What item types will be needed for quest-item mechanics?
-- Should the existing item definitions be repurposed or replaced?
+- What item types will quest mechanics require?
+- Should items be IDs in state or embedded in quest progress only?
 
-**Acceptance Criteria:**
+**Acceptance Criteria (when reintroduced):**
 
-- All items have complete metadata, OR
-- Unused fields are removed from type definition
+- Item types and metadata are complete for every item in use, OR unused fields are removed from the type definition
 
 ---
 
 ### 5.3 Clarify Character Tags System
 
-**Issue:** `MatoranTag` enum exists with only one value (`ChroniclersCompany`), but tags aren't used in game logic.
+**Issue:** `MatoranTag` exists but has limited use in game logic.
 
-**Current:** Tags are defined but not referenced in quests, jobs, or combat.
+**Current:**
 
-**Recommendation:** Either implement tag-based mechanics or remove the system.
+- `MatoranTag.Custom` — used for player-created characters (creation, persistence, share tokens)
+- `MatoranTag.ChroniclersCompany` — set on Chronicler's Company matoran in `src/data/dex/matoran.ts` but not referenced by quests, jobs, or combat
+
+**Recommendation:** Either implement tag-based mechanics for story tags (e.g. Chronicler's Company quest requirements) or remove unused tag values.
 
 **Decision needed:**
 
-- Are tags planned for quest requirements or special abilities?
-- Should the system be removed as premature abstraction?
+- Are tags planned for quest requirements or special abilities beyond custom characters?
+- Should `ChroniclersCompany` drive a mechanic, or be removed as premature abstraction?
 
 **Acceptance Criteria:**
 
-- Tags are used in at least one game mechanic, OR
-- Tag system is removed from types and data
+- Story tags are used in at least one game mechanic, OR
+- Unused tag values are removed from types and data
 
 ---
 
@@ -227,18 +220,23 @@ function detectQuestCycles(quests: Quest[]): string[] {
 
 ---
 
-### 6.3 Complete Mask Hunt Quest Line
+### 6.3 Mask Hunt Unlock Pattern ✅ Documented
 
-**Issue:** `masksCollected` function has hardcoded quest IDs but not all masks have individual unlock quests.
+**Status:** Individual mask quests exist in `src/data/quests/mask_hunt.ts`; `masksCollected` in `src/services/matoranUtils.ts` maps quest IDs to masks per Toa. This is intentional, not an incomplete implementation.
 
-**Current:** Some masks unlock via specific quests, others only via `maskhunt_final_collection`.
+**Unlock pattern (Toa Mata):**
 
-**Recommendation:** Either complete individual mask hunt quests or document the intended unlock pattern.
+- Each Toa starts with their story mask; additional masks unlock via named `maskhunt_*` quests (see the per-Toa `switch` in `masksCollected`).
+- **`maskhunt_final_collection`** grants the full 12-mask set at once (shortcut for players who reach the finale).
+- **`Rau` and `Ruru`** have no individual quest mapping — they are only included via `maskhunt_final_collection` (or the full-set shortcut). All other masks in `FULL_MASK_SET` have at least one individual quest path.
 
-**Acceptance Criteria:**
+**Acceptance Criteria:** Met — pattern is documented here and encoded in `masksCollected` + quest data.
 
-- All masks have individual unlock quests, OR
-- Documentation clarifies which masks are only available via final collection
+---
+
+### 6.4 Custom Matoran Creation & Sharing ✅ Implemented
+
+**Status:** Players can design custom Matoran (`/character-create`), recruit them for protodermis, persist them in `customCharacters`, and share/import via encoded tokens (`customCharacterShare` service). E2E coverage in `e2e/customCharacter.spec.ts`.
 
 ---
 
@@ -246,28 +244,17 @@ function detectQuestCycles(quests: Quest[]): string[] {
 
 ### 7.1 Optimize Job Tick Interval
 
-**Issue:** 5-second tick interval may cause performance issues with many characters.
+**Issue:** 5-second tick interval may cause unnecessary work with many characters.
 
-**Current:** All characters processed every 5 seconds regardless of assignment status.
+**Current:** `useJobTickEffect` maps over every recruited character every 5 seconds. `applyJobExp` in `src/game/Jobs.ts` already no-ops for characters without an assignment (returns `[matoran, 0]` immediately), so idle characters incur only a cheap map iteration, not job math.
 
-**Recommendation:** Only process characters with active assignments.
-
-**Proposed approach:**
-
-```typescript
-setRecruitedCharacters((prev) =>
-  prev.map((matoran) => {
-    if (!matoran.assignment) return matoran; // Skip idle characters
-    // ... process job tick
-  })
-);
-```
+**Recommendation (optional micro-optimization):** Short-circuit at the map level — `if (!matoran.assignment) return matoran` — to avoid object spreads for idle characters when rosters are large.
 
 **Acceptance Criteria:**
 
-- Idle characters are skipped during tick processing
+- Idle characters do no job exp/protodermis work (already true)
+- Optional: map-level skip reduces allocations with 20+ characters
 - No functional changes to job mechanics
-- Performance improvement measurable with 20+ characters
 
 ---
 
@@ -289,21 +276,15 @@ setRecruitedCharacters((prev) =>
 
 ### 7.3 Add Memoization for Expensive Computations
 
-**Issue:** Some computations (quest availability, job unlocks) recalculate on every render.
+**Issue:** Some derived state may still recalculate more often than needed.
 
-**Current:** Functions are called directly in components without memoization.
+**Current:** Many surfaces already use `useMemo` (e.g. `CharacterDetail` tabs/mask info, `CharacterInventory` lists, `Quests` completed sections, `MaskCollection`, recruitment `canRecruit`). Other paths may still recompute on every render.
 
-**Recommendation:** Use `useMemo` for expensive derived state.
-
-**Examples:**
-
-- Quest availability filtering
-- Job unlock status
-- Mask collection status
+**Recommendation:** Audit remaining hot paths (quest availability filtering, job unlock status) and memoize where profiling shows cost.
 
 **Acceptance Criteria:**
 
-- Expensive computations are memoized
+- Expensive computations are memoized where measured
 - Dependencies are correctly specified
 - No stale data issues
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A web-based idle RPG game set in the Bionicle universe, where you recruit Matora
 - **Recruitment System**: Recruit Matoran and Toa characters using protodermis (currency)
 - **Character Progression**: Characters gain XP from jobs and quests, leveling up to become more powerful
 - **Character Customization**: Override mask colors and appearances
+- **Custom Matoran**: Design and recruit your own Matoran; share them via import codes
 - **3D Character Rendering**: View your characters in 3D using React Three Fiber
 
 ### Idle Gameplay
@@ -236,7 +237,8 @@ The game automatically saves to localStorage:
 | [AGENTS.md](AGENTS.md)                             | Cursor Cloud / agent quick reference (commands and caveats)                |
 | [docs/TELEMETRY.md](docs/TELEMETRY.md)             | Optional build-time telemetry (`VITE_TELEMETRY_URL`) and privacy behaviour |
 | [e2e/README.md](e2e/README.md)                     | Playwright E2E tests and snapshot workflow                                 |
-| [ARCHITECTURE_ROADMAP.md](ARCHITECTURE_ROADMAP.md) | Backlog of possible technical improvements (not a commitment)              |
+| [ARCHITECTURE_ROADMAP.md](ARCHITECTURE_ROADMAP.md) | Technical debt and improvement backlog (updated as items land or change)   |
+| [docs/UI_UX_STRATEGY.md](docs/UI_UX_STRATEGY.md) | Portrait-first UI/UX direction and phased 3D expansion plan                |
 
 ## 🤝 Contributing
 

--- a/docs/DESIGN_UI_MOTION_ROLLOUT.md
+++ b/docs/DESIGN_UI_MOTION_ROLLOUT.md
@@ -57,37 +57,37 @@ Optional (future): add a small wrapper module for shared transition presets.
 
 ## Rollout Plan
 
-## Phase 0: Baseline and guardrails
+## Phase 0: Baseline and guardrails ✅ Complete
 
-1. Add the dependency.
-2. Define shared transition presets (durations/easing) aligned with existing CSS tokens.
-3. Add reduced-motion handling for Motion components (`useReducedMotion` + graceful fallbacks).
-4. Ensure test strategy can disable/neutralize UI motion where screenshots are taken.
+1. ✅ Add the dependency (`motion` in `package.json`).
+2. ✅ Define shared transition presets (`src/motion/transitions.ts`).
+3. ✅ Add reduced-motion handling (`useReducedMotion` + `buildTransition` zero-duration fallback).
+4. ✅ Test strategy neutralizes motion in screenshot tests where needed (`isTestMode`, reduced-motion hooks).
 
 ### Exit criteria
 
-- `motion` is installed and builds cleanly.
-- Shared presets exist and are reused by pilot components.
-- Screenshot tests remain stable.
+- ✅ `motion` is installed and builds cleanly.
+- ✅ Shared presets exist and are reused by pilot components.
+- ✅ Screenshot tests remain stable.
 
 ---
 
-## Phase 1 (Pilot): High-impact, low-risk UI surfaces
+## Phase 1 (Pilot): High-impact, low-risk UI surfaces ✅ Complete
 
 ### Pilot scope
 
-1. **Modal enter/exit**
+1. ✅ **Modal enter/exit** (`src/components/Modal/index.tsx`)
    - Backdrop fade
    - Panel fade/scale
    - Proper unmount animation on close
 
-2. **Quests accordion transitions**
-   - Replace `max-height` accordion animation with Motion `height`/`opacity`.
-   - Keep section toggle behavior unchanged.
+2. ✅ **Quests accordion transitions** (`src/pages/Quests/index.tsx`)
+   - Replaced `max-height` accordion animation with Motion `height`/`opacity`.
+   - Section toggle behavior unchanged.
 
-3. **Battle damage popup**
-   - Replace class-reflow keyframe restart with keyed Motion animation.
-   - Keep timing and direction semantics (`up`/`down`) equivalent.
+3. ✅ **Battle damage popup** (`src/pages/Battle/Cards/DamagePopup.tsx`)
+   - Keyed Motion animation replaces class-reflow keyframe restart.
+   - Timing and direction semantics (`up`/`down`) preserved.
 
 ### Why this pilot
 
@@ -103,14 +103,14 @@ Optional (future): add a small wrapper module for shared transition presets.
 
 ---
 
-## Phase 2: Expand to interactive panels
+## Phase 2: Expand to interactive panels (in progress)
 
 Candidate surfaces:
 
-- Chronicle accordion sections/entries
-- Battle prep team selector reveal
-- Recruitment requirement drawer
-- Tooltip entrance/exit polish
+- ✅ Chronicle accordion sections/entries (`src/pages/CharacterDetail/Chronicle/index.tsx`)
+- [ ] Battle prep team selector reveal
+- [ ] Recruitment requirement drawer
+- [ ] Tooltip entrance/exit polish
 
 ### Exit criteria
 
@@ -179,10 +179,12 @@ Because many E2E tests use screenshots:
 
 ## First pilot implementation checklist
 
-- [ ] Install `motion` dependency.
-- [ ] Add shared transition presets module.
-- [ ] Animate `Modal` open/close with `AnimatePresence`.
-- [ ] Animate Quests accordion content with Motion.
-- [ ] Migrate battle damage popups to Motion.
-- [ ] Run lint/tests and update snapshots if needed.
-- [ ] Verify reduced-motion behavior for pilot components.
+- [x] Install `motion` dependency.
+- [x] Add shared transition presets module (`src/motion/transitions.ts`).
+- [x] Animate `Modal` open/close with `motion` + shared presets.
+- [x] Animate Quests accordion content with Motion (`AnimatePresence`).
+- [x] Migrate battle damage popups to Motion.
+- [x] Run lint/tests and update snapshots if needed.
+- [x] Verify reduced-motion behavior for pilot components.
+
+Motion is also adopted more broadly (e.g. `RecruitmentCelebration`, `BattleOutcome`, `CharacterInventory`, `NavBar`, `RahkshiDetail`). Phase 2–3 items above track remaining surfaces.

--- a/docs/UI_UX_STRATEGY.md
+++ b/docs/UI_UX_STRATEGY.md
@@ -46,8 +46,7 @@ This direction maximizes immersion-per-engineering-hour, stays performant on mid
 2. **Battle feedback is split-brain** — The 3D arena sits behind the UI (`z-index: -1`) with models animating, but the player reads combat primarily from 2D cards. The two layers don't reinforce each other; they compete for attention.
 3. **No environmental storytelling** — Every screen has the same dark gradient background. There's no sense of _place_ (Mata Nui, Kini-Nui, Ta-Koro) despite the rich lore.
 4. **Idle progression is invisible** — The only idle indicator is a protodermis counter and job badges. There's no visual heartbeat showing the game is alive when you're on the quests or characters screen.
-5. **Recruitment uses `alert()`** — The most exciting moment (getting a new character) has the worst feedback.
-6. **Text-heavy quest flow** — Available quests are a card list with requirement chips. No visual hook to the world the quest describes.
+5. **Text-heavy quest flow** — Available quests are a card list with requirement chips. No visual hook to the world the quest describes.
 
 ---
 
@@ -63,7 +62,7 @@ This direction maximizes immersion-per-engineering-hour, stays performant on mid
 | **Loot anticipation**         | Krana/kraata drops shown as text rewards                                                   | 3D loot reveal, glow, physical drop from enemy                           |
 | **Sense of place**            | None — every screen is same dark void                                                      | Route-specific 3D backdrops                                              |
 | **Juicy feedback**            | `motion` for layout transitions; damage popups float                                       | Screen shake, particle bursts on crits, elemental VFX on mask powers     |
-| **One-hand reachability**     | Bottom nav is good; battle "Run Round" button is not always thumb-reachable                | Action buttons must live in bottom 40% of viewport                       |
+| **One-hand reachability**     | Bottom nav and battle action bar are thumb-friendly; some secondary actions remain higher  | Keep primary actions in the bottom 40% of the viewport                   |
 
 ---
 
@@ -285,7 +284,7 @@ The codebase uses **GLTF animation clips** stored in the model GLBs. `useCombatA
 
 | Concern                     | Guideline                                                                                                                                                                                                                                       |
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Thumb reach**             | Primary action buttons (Run Round, Recruit, Start Quest) must be in the bottom 40% of viewport height. Current "Run Round" is mid-screen — needs to move down.                                                                                  |
+| **Thumb reach**             | Primary action buttons (Run Round, Recruit, Start Quest) must stay in the bottom 40% of viewport height. Battle actions use a fixed bottom bar above the nav; audit new screens against the same rule.                                         |
 | **Safe areas**              | Use `env(safe-area-inset-top)` and `env(safe-area-inset-bottom)` in CSS. The nav is already 24px from bottom; add `+ env(safe-area-inset-bottom)` for iPhone home indicator.                                                                    |
 | **Text size**               | Minimum 14px for body text, 12px for secondary labels. Current `0.7rem` nav labels (~11.2px) are borderline — consider bumping to `0.75rem`.                                                                                                    |
 | **Touch targets**           | Minimum 44x44px for all interactive elements (WCAG 2.5.8). Current nav items are fine (64px tall); check quest/battle card buttons.                                                                                                             |

--- a/e2e/.playwright-ci-info.md
+++ b/e2e/.playwright-ci-info.md
@@ -37,10 +37,11 @@ Snapshots are stored in the repository at:
 
 ```
 e2e/
-  ├── homepage.spec.ts-snapshots/
   ├── recruitment.spec.ts-snapshots/
-  ├── character-inventory.spec.ts-snapshots/
-  └── ... (other test snapshots)
+  ├── characters/inventory.spec.ts-snapshots/
+  ├── characters/detail/index.spec.ts-snapshots/
+  ├── battle/flow.spec.ts-snapshots/
+  └── ... (other test snapshots alongside their spec files)
 ```
 
 Each snapshot directory contains images for different browsers/viewports:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reviewed `ARCHITECTURE_ROADMAP.md` and related docs against the current codebase. Updated outdated items and marked completed work.

## Changes

### ARCHITECTURE_ROADMAP.md
- **2.1** — Marked ✅ implemented (`RecruitmentCelebration`, disabled recruit button; no `alert()` calls)
- **3.1** — Documented existing ad-hoc save retrocompat in `loadGameState` vs. missing versioned migration framework
- **4.1** — Expanded current test coverage inventory
- **5.1** — Marked ✅ resolved (commented-out CharacterDetail code removed)
- **5.2** — Updated: `ITEM_DICTIONARY` / `GameItemId` removed; item economy deferred
- **5.3** — Updated: `MatoranTag.Custom` in use; `ChroniclersCompany` still unused in mechanics
- **6.3** — Marked ✅ documented (mask unlock pattern, including Rau/Ruru via final collection only)
- **6.4** — Added ✅ implemented custom Matoran creation & sharing
- **7.1 / 7.3** — Clarified current behavior (idle no-op in `applyJobExp`; partial memoization already present)

### Other docs
- **UI_UX_STRATEGY.md** — Removed stale `alert()` weakness; updated thumb-reach notes (battle bottom bar shipped)
- **DESIGN_UI_MOTION_ROLLOUT.md** — Phases 0–1 complete; pilot checklist checked; Phase 2 chronicle done
- **AGENT_GUIDELINES.md** — Removed `ITEM_DICTIONARY` reference; added `customCharacters` to persisted fields
- **e2e/.playwright-ci-info.md** — Fixed snapshot directory examples
- **README.md** — Custom Matoran feature + doc table links

## Still open (unchanged priorities)

- Versioned save migration framework (3.1)
- Quest prerequisite cycle detection (3.2)
- Variable naming consistency (2.2)
- Timestamp unit standardization (5.4)
- Lazy 3D model loading (7.2)
- Ruru/Matatu mask power implementation & tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4b42f6c-9164-408f-b1cf-08a6ac5e01e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4b42f6c-9164-408f-b1cf-08a6ac5e01e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

