### PR TITLE
feat: pause job ticks during battle

### DIFF
--- a/AGENT_GUIDELINES.md
+++ b/AGENT_GUIDELINES.md
@@ -211,13 +211,15 @@ All game state must flow through the single `GameContext` provided by `GameProvi
 
 ### Forbidden: Breaking the Job Tick Contract
 
-The `useJobTickEffect` hook runs on an interval and processes all assigned jobs.
+The `useJobTickEffect` hook runs on an interval and processes all assigned jobs. It pauses while `battle.phase !== Idle`: interval ticks stop during battle, partial progress is flushed at battle start, and elapsed time is applied on resume via `applyJobExp` catch-up.
 
 **NEVER** create multiple job tick intervals.
 
 **NEVER** process job exp outside of `applyJobExp` or `applyOfflineJobExp`.
 
 **NEVER** modify the job tick logic without ensuring offline progress calculations remain consistent.
+
+**NEVER** run job ticks during active battle outside of the pause/resume flush and catch-up handled by `useJobTickEffect`.
 
 ---
 

--- a/ARCHITECTURE_ROADMAP.md
+++ b/ARCHITECTURE_ROADMAP.md
@@ -242,19 +242,21 @@ function detectQuestCycles(quests: Quest[]): string[] {
 
 ## Priority 7: Performance & Scalability (Low Priority)
 
-### 7.1 Optimize Job Tick Interval
+### 7.1 Optimize Job Tick Interval ✅ Implemented
 
-**Issue:** 5-second tick interval may cause unnecessary work with many characters.
+**Status:** Resolved.
 
-**Current:** `useJobTickEffect` maps over every recruited character every 5 seconds. `applyJobExp` in `src/game/Jobs.ts` already no-ops for characters without an assignment (returns `[matoran, 0]` immediately), so idle characters incur only a cheap map iteration, not job math.
+**Implementation:**
 
-**Recommendation (optional micro-optimization):** Short-circuit at the map level — `if (!matoran.assignment) return matoran` — to avoid object spreads for idle characters when rosters are large.
+- **Battle pause:** `useJobTickEffect` stops its 5-second interval while `battle.phase !== Idle`. On battle start it flushes the partial interval via `applyJobExp`; on resume it applies elapsed battle time through the same catch-up path. This avoids main-thread spikes from full save rewrites and broad `useGame()` re-renders during combat.
+- **Map-level skip:** `tickRecruitedCharactersJobExp` in `src/services/jobUtils.ts` and `applyOfflineJobExp` in `src/game/Jobs.ts` return idle roster members unchanged (`if (!matoran.assignment) return matoran`), avoiding object spreads when rosters are large.
+- **Batched protodermis:** Each tick aggregates protodermis across assigned characters into a single `addProtodermis` call.
 
 **Acceptance Criteria:**
 
-- Idle characters do no job exp/protodermis work (already true)
-- Optional: map-level skip reduces allocations with 20+ characters
-- No functional changes to job mechanics
+- Idle characters do no job exp/protodermis work ✅
+- Map-level skip reduces allocations with large rosters ✅
+- No functional changes to job mechanics ✅
 
 ---
 

--- a/src/game/Jobs.spec.ts
+++ b/src/game/Jobs.spec.ts
@@ -434,4 +434,27 @@ describe('Jobs', () => {
       });
     });
   });
+
+  describe('battle pause catch-up via applyJobExp', () => {
+    test('applyJobExp after assignedAt reset at battle start covers battle elapsed', () => {
+      const battleStart = 1_000;
+      const battleEnd = 61_000;
+      const matoran: RecruitedCharacterData = {
+        assignment: {
+          assignedAt: 0,
+          expRatePerSecond: 1,
+          job: MatoranJob.CharcoalMaker,
+        },
+        exp: 0,
+        id: 'Jala',
+      };
+
+      const [atBattleStart] = applyJobExp(matoran, battleStart);
+      const [afterBattle, earned] = applyJobExp(atBattleStart, battleEnd);
+
+      expect(earned).toBe(60);
+      expect(afterBattle.exp).toBe(61);
+      expect(afterBattle.assignment?.assignedAt).toBe(battleEnd);
+    });
+  });
 });

--- a/src/game/Jobs.ts
+++ b/src/game/Jobs.ts
@@ -122,6 +122,8 @@ export function applyOfflineJobExp(
   let currencyGain = 0;
 
   const updated = characters.map((m) => {
+    if (!m.assignment) return m;
+
     const [updatedMatoran, earned] = applyJobExp(m, now, true);
 
     if (earned > 0) {

--- a/src/hooks/useGameLogic.tsx
+++ b/src/hooks/useGameLogic.tsx
@@ -8,7 +8,7 @@ import { useGamePersistence } from './useGamePersistence';
 import { GameState, GameStateEditorApi } from '../types/GameState';
 import { useQuestState } from './useQuestState';
 import { useQuestNotifications } from './useQuestNotifications';
-import { useBattleState } from './useBattleState';
+import { BattlePhase, useBattleState } from './useBattleState';
 import { clamp } from '../utils/math';
 import { KranaCollection, KranaElement, KranaId } from '../types/Krana';
 import { BattleRewardParams, KranaReward } from '../types/GameState';
@@ -117,13 +117,15 @@ export const useGameLogic = (): GameState & GameStateEditorApi => {
   recruitedCharactersRef.current = recruitedCharacters;
   setRecruitedCharactersRef.current = setRecruitedCharacters;
 
-  useJobTickEffect(setRecruitedCharacters, (amount) =>
-    setProtodermis((prev) => clamp(prev + amount, 0, protodermisCap))
+  const battle = useBattleState(isNuvaSymbolsSequestered(completedQuests));
+
+  useJobTickEffect(
+    setRecruitedCharacters,
+    (amount) => setProtodermis((prev) => clamp(prev + amount, 0, protodermisCap)),
+    battle.phase !== BattlePhase.Idle
   );
 
   useQuestNotifications(activeQuests);
-
-  const battle = useBattleState(isNuvaSymbolsSequestered(completedQuests));
 
   // Auto-save when critical state changes (buyableCharacters is derived, not persisted)
   useGamePersistence({

--- a/src/hooks/useJobTickEffect.spec.tsx
+++ b/src/hooks/useJobTickEffect.spec.tsx
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { useState } from 'react';
+import { MatoranJob } from '../types/Jobs';
+import { RecruitedCharacterData } from '../types/Matoran';
+import { useJobTickEffect } from './useJobTickEffect';
+
+const jobMatoran = (assignedAt: number): RecruitedCharacterData => ({
+  assignment: {
+    assignedAt,
+    expRatePerSecond: 1,
+    job: MatoranJob.CharcoalMaker,
+  },
+  exp: 0,
+  id: 'Jala',
+});
+
+function useJobTickHarness(paused: boolean) {
+  const [recruitedCharacters, setRecruitedCharacters] = useState<RecruitedCharacterData[]>([
+    jobMatoran(0),
+  ]);
+  const [protodermis, setProtodermis] = useState(0);
+
+  useJobTickEffect(
+    setRecruitedCharacters,
+    (amount) => setProtodermis((prev) => prev + amount),
+    paused
+  );
+
+  return { protodermis, recruitedCharacters };
+}
+
+describe('useJobTickEffect', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('ticks job exp on interval when not paused', () => {
+    const { result } = renderHook(() => useJobTickHarness(false));
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.recruitedCharacters[0].exp).toBe(5);
+  });
+
+  test('does not tick while paused', () => {
+    const { rerender, result } = renderHook(({ paused }) => useJobTickHarness(paused), {
+      initialProps: { paused: false },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    rerender({ paused: true });
+
+    act(() => {
+      jest.advanceTimersByTime(20_000);
+    });
+
+    // Flush at pause start (2s) only; no further ticks during battle.
+    expect(result.current.recruitedCharacters[0].exp).toBe(2);
+  });
+
+  test('applies battle elapsed time when resuming after pause', () => {
+    const { rerender, result } = renderHook(({ paused }) => useJobTickHarness(paused), {
+      initialProps: { paused: false },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    rerender({ paused: true });
+
+    act(() => {
+      jest.setSystemTime(61_000);
+      jest.advanceTimersByTime(0);
+    });
+
+    rerender({ paused: false });
+
+    // 1s flushed at battle start + 60s battle duration = 61 exp
+    expect(result.current.recruitedCharacters[0].exp).toBe(61);
+  });
+});

--- a/src/hooks/useJobTickEffect.tsx
+++ b/src/hooks/useJobTickEffect.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { RecruitedCharacterData } from '../types/Matoran';
 import { tickMatoranJobExp } from '../services/jobUtils';
 
@@ -7,17 +7,76 @@ export function useJobTickEffect(
     fn: (prev: RecruitedCharacterData[]) => RecruitedCharacterData[]
   ) => void,
   addProtodermis: (amount: number) => void,
+  /** When true (e.g. during battle), interval ticks stop; elapsed time is applied on resume. */
+  paused: boolean,
   intervalMs: number = 5000
 ) {
+  const setRecruitedCharactersRef = useRef(setRecruitedCharacters);
+  const addProtodermisRef = useRef(addProtodermis);
+  setRecruitedCharactersRef.current = setRecruitedCharacters;
+  addProtodermisRef.current = addProtodermis;
+
+  const pauseStartedAtRef = useRef<number | null>(null);
+  const wasPausedRef = useRef<boolean | null>(null);
+
   useEffect(() => {
+    const wasPaused = wasPausedRef.current;
+    wasPausedRef.current = paused;
+
+    if (wasPaused === null) {
+      return;
+    }
+
+    if (!wasPaused && paused) {
+      const pauseStartedAt = Date.now();
+      pauseStartedAtRef.current = pauseStartedAt;
+
+      // Flush the partial interval since the last tick so battle-start time is not lost.
+      setRecruitedCharactersRef.current((prev) => {
+        let protodermisGain = 0;
+        const updated = prev.map((matoran) => {
+          const { earnedProtodermis, updatedMatoran } = tickMatoranJobExp(matoran, pauseStartedAt);
+          protodermisGain += earnedProtodermis;
+          return updatedMatoran;
+        });
+        if (protodermisGain > 0) {
+          addProtodermisRef.current(protodermisGain);
+        }
+        return updated;
+      });
+    } else if (wasPaused && !paused) {
+      if (pauseStartedAtRef.current === null) return;
+      pauseStartedAtRef.current = null;
+
+      const now = Date.now();
+
+      // assignedAt was reset to battle start on pause; applyJobExp(now) covers battle elapsed.
+      setRecruitedCharactersRef.current((prev) => {
+        let protodermisGain = 0;
+        const updated = prev.map((matoran) => {
+          const { earnedProtodermis, updatedMatoran } = tickMatoranJobExp(matoran, now);
+          protodermisGain += earnedProtodermis;
+          return updatedMatoran;
+        });
+        if (protodermisGain > 0) {
+          addProtodermisRef.current(protodermisGain);
+        }
+        return updated;
+      });
+    }
+  }, [paused]);
+
+  useEffect(() => {
+    if (paused) return;
+
     const interval = setInterval(() => {
       const now = Date.now();
 
-      setRecruitedCharacters((prev) =>
+      setRecruitedCharactersRef.current((prev) =>
         prev.map((matoran) => {
           const { earnedProtodermis, updatedMatoran } = tickMatoranJobExp(matoran, now);
 
-          if (earnedProtodermis > 0) addProtodermis(earnedProtodermis);
+          if (earnedProtodermis > 0) addProtodermisRef.current(earnedProtodermis);
 
           return updatedMatoran;
         })
@@ -25,5 +84,5 @@ export function useJobTickEffect(
     }, intervalMs);
 
     return () => clearInterval(interval);
-  }, [setRecruitedCharacters, addProtodermis, intervalMs]);
+  }, [paused, intervalMs]);
 }

--- a/src/hooks/useJobTickEffect.tsx
+++ b/src/hooks/useJobTickEffect.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { RecruitedCharacterData } from '../types/Matoran';
-import { tickMatoranJobExp } from '../services/jobUtils';
+import { tickRecruitedCharactersJobExp } from '../services/jobUtils';
 
 export function useJobTickEffect(
   setRecruitedCharacters: (
@@ -33,12 +33,7 @@ export function useJobTickEffect(
 
       // Flush the partial interval since the last tick so battle-start time is not lost.
       setRecruitedCharactersRef.current((prev) => {
-        let protodermisGain = 0;
-        const updated = prev.map((matoran) => {
-          const { earnedProtodermis, updatedMatoran } = tickMatoranJobExp(matoran, pauseStartedAt);
-          protodermisGain += earnedProtodermis;
-          return updatedMatoran;
-        });
+        const { protodermisGain, updated } = tickRecruitedCharactersJobExp(prev, pauseStartedAt);
         if (protodermisGain > 0) {
           addProtodermisRef.current(protodermisGain);
         }
@@ -52,12 +47,7 @@ export function useJobTickEffect(
 
       // assignedAt was reset to battle start on pause; applyJobExp(now) covers battle elapsed.
       setRecruitedCharactersRef.current((prev) => {
-        let protodermisGain = 0;
-        const updated = prev.map((matoran) => {
-          const { earnedProtodermis, updatedMatoran } = tickMatoranJobExp(matoran, now);
-          protodermisGain += earnedProtodermis;
-          return updatedMatoran;
-        });
+        const { protodermisGain, updated } = tickRecruitedCharactersJobExp(prev, now);
         if (protodermisGain > 0) {
           addProtodermisRef.current(protodermisGain);
         }
@@ -72,15 +62,13 @@ export function useJobTickEffect(
     const interval = setInterval(() => {
       const now = Date.now();
 
-      setRecruitedCharactersRef.current((prev) =>
-        prev.map((matoran) => {
-          const { earnedProtodermis, updatedMatoran } = tickMatoranJobExp(matoran, now);
-
-          if (earnedProtodermis > 0) addProtodermisRef.current(earnedProtodermis);
-
-          return updatedMatoran;
-        })
-      );
+      setRecruitedCharactersRef.current((prev) => {
+        const { protodermisGain, updated } = tickRecruitedCharactersJobExp(prev, now);
+        if (protodermisGain > 0) {
+          addProtodermisRef.current(protodermisGain);
+        }
+        return updated;
+      });
     }, intervalMs);
 
     return () => clearInterval(interval);

--- a/src/services/jobUtils.spec.ts
+++ b/src/services/jobUtils.spec.ts
@@ -1,0 +1,41 @@
+import { MatoranJob } from '../types/Jobs';
+import { RecruitedCharacterData } from '../types/Matoran';
+import { tickRecruitedCharactersJobExp } from './jobUtils';
+
+const jobMatoran = (assignedAt: number, id = 'Jala'): RecruitedCharacterData => ({
+  assignment: {
+    assignedAt,
+    expRatePerSecond: 1,
+    job: MatoranJob.CharcoalMaker,
+  },
+  exp: 0,
+  id,
+});
+
+const idleMatoran = (id: string): RecruitedCharacterData => ({
+  exp: 0,
+  id,
+});
+
+describe('tickRecruitedCharactersJobExp', () => {
+  test('skips idle characters without creating new object references', () => {
+    const idle = idleMatoran('Hahli');
+    const working = jobMatoran(0);
+    const roster = [idle, working];
+
+    const { protodermisGain, updated } = tickRecruitedCharactersJobExp(roster, 10_000);
+
+    expect(updated[0]).toBe(idle);
+    expect(updated[1].exp).toBe(10);
+    expect(protodermisGain).toBe(1);
+  });
+
+  test('returns zero protodermis when no characters are assigned', () => {
+    const roster = [idleMatoran('Hahli'), idleMatoran('Macku')];
+
+    const { protodermisGain, updated } = tickRecruitedCharactersJobExp(roster, 5000);
+
+    expect(updated).toEqual(roster);
+    expect(protodermisGain).toBe(0);
+  });
+});

--- a/src/services/jobUtils.ts
+++ b/src/services/jobUtils.ts
@@ -18,3 +18,26 @@ export function tickMatoranJobExp(matoran: RecruitedCharacterData, now: number):
     updatedMatoran: updated,
   };
 }
+
+type TickRosterResult = {
+  updated: RecruitedCharacterData[];
+  protodermisGain: number;
+};
+
+/** Applies one online job tick to every assigned character; idle roster members are unchanged. */
+export function tickRecruitedCharactersJobExp(
+  characters: RecruitedCharacterData[],
+  now: number
+): TickRosterResult {
+  let protodermisGain = 0;
+
+  const updated = characters.map((matoran) => {
+    if (!matoran.assignment) return matoran;
+
+    const { earnedProtodermis, updatedMatoran } = tickMatoranJobExp(matoran, now);
+    protodermisGain += earnedProtodermis;
+    return updatedMatoran;
+  });
+
+  return { protodermisGain, updated };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fully implements **Architecture Roadmap §7.1 (Optimize Job Tick Interval)** by pausing the 5-second job tick during battle and applying the remaining performance optimizations.

## Behavior

- **Battle start:** flush partial pre-battle interval via `applyJobExp` (sets `assignedAt` to pause time)
- **During battle:** no interval ticks while `battle.phase !== Idle`
- **Battle end:** `applyJobExp` catch-up for elapsed battle time (same code path as live ticks)

## Performance optimizations (§7.1)

- **Battle pause** — avoids main-thread spikes from full save rewrites and broad `useGame()` re-renders during combat
- **Map-level skip** — `tickRecruitedCharactersJobExp` and `applyOfflineJobExp` return idle roster members unchanged (`!matoran.assignment`)
- **Batched protodermis** — one `addProtodermis` call per tick instead of per character

## Files

- `src/hooks/useJobTickEffect.tsx` — pause/resume logic
- `src/hooks/useGameLogic.tsx` — wires `battle.phase !== Idle`
- `src/services/jobUtils.ts` — shared `tickRecruitedCharactersJobExp` helper
- `src/game/Jobs.ts` — map-level skip in `applyOfflineJobExp`
- `src/hooks/useJobTickEffect.spec.tsx` — hook tests
- `src/services/jobUtils.spec.ts` — helper tests
- `src/game/Jobs.spec.ts` — documents flush + resume pattern
- `ARCHITECTURE_ROADMAP.md` — marks §7.1 complete
- `AGENT_GUIDELINES.md` — documents battle pause contract

## Tests

`yarn test:ci` (all 364 tests pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68f82d91-838c-4477-a63e-43ec46764433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68f82d91-838c-4477-a63e-43ec46764433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

