### PR TITLE
Implement Ruru (Mask of Night Vision) combat power

### DIFF
--- a/src/services/battleSimulation.spec.ts
+++ b/src/services/battleSimulation.spec.ts
@@ -379,6 +379,81 @@ describe('Battle Simulation', () => {
       expect(sim.team.length).toBe(2);
     });
 
+    test('Ruru applies ACCURACY_MULT to every living enemy on activation', async () => {
+      const team = createTeamFromRecruited([{ exp: 0, id: 'Toa_Onua', maskOverride: Mask.Ruru }]);
+      const encounter = ENCOUNTERS.find((e) => e.id === 'tahnok-1')!;
+      const customEncounter: EnemyEncounter = {
+        ...encounter,
+        waves: [
+          [
+            { id: 'tahnok', lvl: 1 },
+            { id: 'tahnok', lvl: 1 },
+          ],
+        ],
+      };
+
+      const sim = new BattleSimulator(team, customEncounter);
+      sim.team = setAbilities(sim.team, ['Toa_Onua'], true);
+
+      await sim.runRound();
+
+      expect(
+        sim.enemies.every((enemy) =>
+          enemy.effects?.some(
+            (effect) => effect.type === 'ACCURACY_MULT' && effect.multiplier === 0.5
+          )
+        )
+      ).toBe(true);
+      const onua = sim.team.find((t) => t.id === 'Toa_Onua')!;
+      expect(onua.maskPower?.active).toBe(true);
+      expect(hasActiveEffectFromSource(sim.team, sim.enemies, 'Toa_Onua')).toBe(true);
+    });
+
+    test('Ruru blinded enemy misses their attack', async () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0.6);
+
+      const team = createTeamFromRecruited([{ exp: 0, id: 'Toa_Onua', maskOverride: Mask.Ruru }]);
+      const encounter = ENCOUNTERS.find((e) => e.id === 'tahnok-1')!;
+      const customEncounter: EnemyEncounter = {
+        ...encounter,
+        waves: [[{ id: 'tahnok', lvl: 1 }]],
+      };
+
+      const sim = new BattleSimulator(team, customEncounter);
+      const hpBefore = sim.team[0].hp;
+      sim.team = setAbilities(sim.team, ['Toa_Onua'], true);
+
+      await sim.runRound();
+
+      expect(sim.team[0].hp).toBe(hpBefore);
+      expect(sim.enemies[0].effects?.some((effect) => effect.type === 'ACCURACY_MULT')).toBe(true);
+    });
+
+    test('Ruru ACCURACY_MULT lasts exactly 2 enemy turns', async () => {
+      const team = createTeamFromRecruited([{ exp: 0, id: 'Toa_Onua', maskOverride: Mask.Ruru }]);
+      const encounter = ENCOUNTERS.find((e) => e.id === 'tahnok-1')!;
+      const customEncounter: EnemyEncounter = {
+        ...encounter,
+        waves: [[{ id: 'tahnok', lvl: 1 }]],
+      };
+
+      const sim = new BattleSimulator(team, customEncounter);
+      sim.team = setAbilities(sim.team, ['Toa_Onua'], true);
+      await sim.runRound();
+
+      const blindEffectAfterR1 = sim.enemies[0].effects?.find(
+        (effect) => effect.type === 'ACCURACY_MULT'
+      );
+      expect(blindEffectAfterR1?.durationRemaining).toBe(1);
+
+      sim.team = setAbilities(sim.team, [], false);
+      await sim.runRound();
+
+      expect(
+        sim.enemies[0].effects?.some((effect) => effect.type === 'ACCURACY_MULT') ?? false
+      ).toBe(false);
+    });
+
     test('Komau CONFUSION makes enemy attack their own team', async () => {
       const team = createTeamFromRecruited([{ exp: 0, id: 'Toa_Tahu', maskOverride: Mask.Komau }]);
       const encounter = ENCOUNTERS.find((e) => e.id === 'tahnok-1')!;

--- a/src/services/combatUtils.spec.ts
+++ b/src/services/combatUtils.spec.ts
@@ -421,6 +421,15 @@ describe('chooseTarget', () => {
       expect(matoran.maskPower?.effect.type).toBe('AGGRO');
     });
 
+    test('generates combatant with Ruru mask (ACCURACY_MULT)', () => {
+      const onua = generateCombatantStats('onua', 'Toa_Onua', 1, Mask.Ruru);
+
+      expect(onua.maskPower).toBeDefined();
+      expect(onua.maskPower?.effect.type).toBe('ACCURACY_MULT');
+      expect(onua.maskPower?.target).toBe('allEnemies');
+      expect(onua.maskPower?.effect.multiplier).toBe(0.5);
+    });
+
     test('mask power has duration and cooldown properties', () => {
       const tahu = generateCombatantStats('tahu', 'Toa_Tahu', 1, Mask.Hau);
 

--- a/src/services/combatUtils.ts
+++ b/src/services/combatUtils.ts
@@ -142,10 +142,30 @@ export const ELEMENT_EFFECTIVENESS: Record<ElementTribe, Record<ElementTribe, nu
   },
 };
 
+const BASE_HIT_CHANCE = 1;
 const CRIT_CHANCE = 0.125;
 const CRIT_DAMAGE_MULT = 1.5;
 
 export type AtkDamageResult = { damage: number; isCritical: boolean };
+
+/** Product of active ACCURACY_MULT effects on the attacker (1 = normal accuracy). */
+export function getAccuracyMultiplier(combatant: Combatant): number {
+  let mult = 1;
+  for (const e of combatant.effects ?? []) {
+    if (e.type === 'ACCURACY_MULT' && e.durationRemaining > 0) {
+      mult *= e.multiplier;
+    }
+  }
+  return mult;
+}
+
+/** Whether the attacker's swing connects (Ruru and future accuracy effects). */
+export function rollAttackHits(attacker: Combatant): boolean {
+  const hitChance = BASE_HIT_CHANCE * getAccuracyMultiplier(attacker);
+  if (hitChance >= 1) return true;
+  if (hitChance <= 0) return false;
+  return Math.random() < hitChance;
+}
 
 export function calculateAtkDmg(attacker: Combatant, defender: Combatant): AtkDamageResult {
   // DEFENSE multiplies the defense stat: >1 = fortify, <1 = weaken
@@ -255,6 +275,16 @@ function createEffectFromMaskEffect(
         multiplier: effect.multiplier ?? 1,
         sourceId,
         type: 'DEFENSE',
+      };
+    }
+    case 'ACCURACY_MULT': {
+      const unit = dur.unit === 'turn' || dur.unit === 'round' ? dur.unit : 'turn';
+      return {
+        durationRemaining: amount,
+        durationUnit: unit,
+        multiplier: effect.multiplier ?? 1,
+        sourceId,
+        type: 'ACCURACY_MULT',
       };
     }
     case 'CONFUSION': {
@@ -512,6 +542,20 @@ function triggerMaskPowers(
             }
           }
         }
+      } else if (actor.maskPower.target === 'allEnemies') {
+        // All-enemies mask (e.g. Ruru): apply effect to every living opponent.
+        const eff = createEffectFromMaskEffect(effect, actor.id);
+        if (eff) {
+          if (isTeam) {
+            currentEnemies = currentEnemies.map((e) =>
+              e.hp > 0 ? applyEffectToCombatant(e, eff) : e
+            );
+          } else {
+            currentTeam = currentTeam.map((t) =>
+              t.hp > 0 ? applyEffectToCombatant(t, eff) : t
+            );
+          }
+        }
       } else if (actor.maskPower.target === 'self') {
         // Self-target: apply effect to caster. Effects drive changes; mask target is only for application.
         const eff = createEffectFromMaskEffect(effect, actor.id);
@@ -643,8 +687,11 @@ export function queueCombatRound(
         else currentTeam = newOpponentListForMark;
       }
 
-      const { damage, isCritical } = calculateAtkDmg(self, target);
-      const willBeDefeated = target.hp - damage <= 0;
+      const attackHits = rollAttackHits(self);
+      const { damage, isCritical } = attackHits
+        ? calculateAtkDmg(self, target)
+        : { damage: 0, isCritical: false };
+      const willBeDefeated = attackHits && target.hp - damage <= 0;
 
       // Expect 3D combatant refs to be globally accessible for now
       const actorRef = window.combatantRefs?.[self.id];
@@ -667,8 +714,8 @@ export function queueCombatRound(
         }
 
         // Apply damage and update state when contact occurs (HP bar drops at impact)
-        let updatedTarget = applyDamage(target, damage);
-        const damageDealt = target.hp - updatedTarget.hp;
+        let updatedTarget = attackHits ? applyDamage(target, damage) : target;
+        const damageDealt = attackHits ? target.hp - updatedTarget.hp : 0;
         if (damageDealt > 0) {
           emitBattleHitFeedback({
             attackerElement: self.element,
@@ -686,8 +733,10 @@ export function queueCombatRound(
         self = decrementEffectDurations(self, 'attack');
 
         // Decrement 'hit' unit counters for defender (mask + buffs)
-        updatedTarget = decrementMaskPowerCounter(updatedTarget, 'hit');
-        updatedTarget = decrementEffectDurations(updatedTarget, 'hit');
+        if (attackHits) {
+          updatedTarget = decrementMaskPowerCounter(updatedTarget, 'hit');
+          updatedTarget = decrementEffectDurations(updatedTarget, 'hit');
+        }
 
         // Decrement 'turn' unit counters ONLY for the combatant whose turn it is
         self = decrementMaskPowerCounter(self, 'turn');
@@ -736,7 +785,12 @@ export function queueCombatRound(
         // and Hit/Defeat runs stopAllAction(), which would cancel the in-progress Attack clip.
         // Skip when targetRef === actorRef with different ids (stale combatantRefs map): Hit would
         // run on the attacker's mixer and cancel Attack.
-        if (target.id !== self.id && targetRef?.playAnimation && targetRef !== actorRef) {
+        if (
+          attackHits &&
+          target.id !== self.id &&
+          targetRef?.playAnimation &&
+          targetRef !== actorRef
+        ) {
           if (willBeDefeated) {
             pendingAnimations.push(targetRef.playAnimation('Defeat', { faceTargetId: self.id }));
           } else {

--- a/src/services/maskPowers.spec.ts
+++ b/src/services/maskPowers.spec.ts
@@ -6,6 +6,8 @@ import {
   applyDamage,
   applyHealing,
   chooseTarget,
+  getAccuracyMultiplier,
+  rollAttackHits,
 } from './combatUtils';
 
 describe('Mask Powers - Combat Mechanics', () => {
@@ -249,6 +251,71 @@ describe('Mask Powers - Combat Mechanics', () => {
       const chosen = chooseTarget(attacker, targets);
 
       expect(chosen.id).toBe('enemy_huna');
+    });
+  });
+
+  describe('ACCURACY_MULT - Ruru (Mask of Night Vision)', () => {
+    test('getAccuracyMultiplier returns 1 with no effects', () => {
+      const attacker = generateCombatantStats('onua', 'Toa_Onua', 1, Mask.Ruru);
+      expect(getAccuracyMultiplier(attacker)).toBe(1);
+    });
+
+    test('getAccuracyMultiplier applies active ACCURACY_MULT multiplicatively', () => {
+      const attacker = generateCombatantStats('onua', 'Toa_Onua', 1, Mask.Ruru);
+      attacker.effects = [
+        {
+          durationRemaining: 2,
+          durationUnit: 'turn',
+          multiplier: 0.5,
+          sourceId: 'caster',
+          type: 'ACCURACY_MULT',
+        },
+      ];
+      expect(getAccuracyMultiplier(attacker)).toBe(0.5);
+    });
+
+    test('getAccuracyMultiplier stacks multiple ACCURACY_MULT effects', () => {
+      const attacker = generateCombatantStats('onua', 'Toa_Onua', 1, Mask.Ruru);
+      attacker.effects = [
+        {
+          durationRemaining: 2,
+          durationUnit: 'turn',
+          multiplier: 0.5,
+          sourceId: 'caster-a',
+          type: 'ACCURACY_MULT',
+        },
+        {
+          durationRemaining: 1,
+          durationUnit: 'turn',
+          multiplier: 0.5,
+          sourceId: 'caster-b',
+          type: 'ACCURACY_MULT',
+        },
+      ];
+      expect(getAccuracyMultiplier(attacker)).toBe(0.25);
+    });
+
+    test('rollAttackHits always succeeds without accuracy debuffs', () => {
+      const attacker = generateCombatantStats('onua', 'Toa_Onua', 1, Mask.Ruru);
+      jest.spyOn(Math, 'random').mockReturnValue(0.99);
+      expect(rollAttackHits(attacker)).toBe(true);
+    });
+
+    test('rollAttackHits can miss when ACCURACY_MULT halves hit chance', () => {
+      const attacker = generateCombatantStats('onua', 'Toa_Onua', 1, Mask.Ruru);
+      attacker.effects = [
+        {
+          durationRemaining: 2,
+          durationUnit: 'turn',
+          multiplier: 0.5,
+          sourceId: 'caster',
+          type: 'ACCURACY_MULT',
+        },
+      ];
+      jest.spyOn(Math, 'random').mockReturnValue(0.6);
+      expect(rollAttackHits(attacker)).toBe(false);
+      jest.spyOn(Math, 'random').mockReturnValue(0.4);
+      expect(rollAttackHits(attacker)).toBe(true);
     });
   });
 

--- a/src/types/Combat.ts
+++ b/src/types/Combat.ts
@@ -61,6 +61,13 @@ export type TargetEffect =
       sourceId: string;
     }
   | {
+      type: 'ACCURACY_MULT';
+      multiplier: number;
+      durationRemaining: number;
+      durationUnit: 'turn' | 'round';
+      sourceId: string;
+    }
+  | {
       type: 'CONFUSION';
       durationRemaining: number;
       durationUnit: 'turn' | 'round';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fully implements the Ruru mask power: blinding all enemies with a turn-based accuracy debuff that can cause attacks to miss.

## Changes

### Types (`src/types/Combat.ts`)
- Add `ACCURACY_MULT` to the `TargetEffect` discriminated union

### Combat logic (`src/services/combatUtils.ts`)
- `getAccuracyMultiplier` / `rollAttackHits` — hit chance is `BASE_HIT_CHANCE` (100%) × product of active `ACCURACY_MULT` effects
- `createEffectFromMaskEffect` — builds `ACCURACY_MULT` debuffs (Ruru: 0.5× for 2 turns)
- `triggerMaskPowers` — handles `target: 'allEnemies'` by applying the effect to every living opponent
- Attack loop — rolls hit before damage; misses skip damage, hit feedback, and target Hit/Defeat animations

### Tests
- **maskPowers.spec.ts** — accuracy multiplier stacking and hit/miss rolls
- **combatUtils.spec.ts** — Ruru mask generation
- **battleSimulation.spec.ts** — all-enemy debuff on activation, blinded enemy miss, 2-turn duration expiry

## Behavior

| Property | Value |
|---|---|
| Target | All living enemies |
| Effect | 50% hit chance for 2 turns (per enemy, decrements on their turn) |
| Cooldown | 4 turns |

## Testing

- `yarn lint` — pass
- `yarn test:ci` — pass (373 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4432151-7955-4778-a03f-83f320ebcbdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4432151-7955-4778-a03f-83f320ebcbdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

