### PR TITLE
Update docs for Ruru + skip CI on docs-only changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,61 @@ on:
       - main
 
 jobs:
+  # Skip Test / E2E / Build when the diff only touches Markdown (docs, README, etc.)
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.docs_only.outputs.docs_only }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect docs-only diff
+        id: docs_only
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+          if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          mapfile -t files < <(git diff --name-only "$BASE" "$HEAD")
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          for f in "${files[@]}"; do
+            case "$f" in
+              *.md) ;;
+              *)
+                echo "docs_only=false" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+            esac
+          done
+          echo "docs_only=true" >> "$GITHUB_OUTPUT"
+
+  docs-only:
+    name: Docs only (CI skipped)
+    needs: changes
+    if: needs.changes.outputs.docs_only == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Markdown-only change; Test, E2E, and Build were skipped."
+
   # Job 1: Run tests and linting
   test:
     name: Test & Lint
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -38,6 +90,8 @@ jobs:
   # Job 2: E2E Visual Tests
   e2e:
     name: E2E Visual Tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -79,7 +133,11 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [test, e2e]
+    needs: [changes, test, e2e]
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.test.result == 'success' &&
+      needs.e2e.result == 'success'
 
     steps:
       - name: Checkout code
@@ -111,8 +169,12 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    needs: [changes, build]
+    if: >-
+      github.ref == 'refs/heads/master' &&
+      github.event_name == 'push' &&
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.build.result == 'success'
 
     steps:
       - name: Checkout code

--- a/ARCHITECTURE_ROADMAP.md
+++ b/ARCHITECTURE_ROADMAP.md
@@ -123,11 +123,11 @@ function detectQuestCycles(quests: Quest[]): string[] {
 
 **Issue:** Minimal test coverage, especially for pure game logic functions.
 
-**Current:** Unit tests exist across `src/game/` (e.g. `Levelling`, `Jobs`, `Quests`, `BattleRewards`, `Krana`, `CharacterEvolution`, `masks`, `nuvaSymbols`, `ProtodermisConversion`, `encounterVisibility`, `customMataBuild`) and `src/services/` (e.g. `combatUtils`, `maskPowers`, `maskPowerCooldowns`, `battleSimulation`, `gamePersistence`, `matoranUtils`, `customCharacterShare`). E2E coverage includes recruitment, quests, cutscenes, custom characters, battle flow, and character detail. Coverage is substantially improved but not yet comprehensive (e.g. some mask powers like Ruru/Matatu remain untested in combat).
+**Current:** Unit tests exist across `src/game/` (e.g. `Levelling`, `Jobs`, `Quests`, `BattleRewards`, `Krana`, `CharacterEvolution`, `masks`, `nuvaSymbols`, `ProtodermisConversion`, `encounterVisibility`, `customMataBuild`) and `src/services/` (e.g. `combatUtils`, `maskPowers`, `maskPowerCooldowns`, `battleSimulation`, `gamePersistence`, `matoranUtils`, `customCharacterShare`). E2E coverage includes recruitment, quests, cutscenes, custom characters, battle flow, and character detail. Coverage is substantially improved but not yet comprehensive (e.g. Matatu immobilize remains unimplemented in combat).
 
 **Recommendation:** Continue adding tests for critical game logic and combat edge cases:
 
-- Remaining mask power implementations (`Ruru`, `Matatu`)
+- Remaining mask power implementation (`Matatu` immobilize)
 - Quest prerequisite validation (see 3.2)
 - Integration paths for custom character share/recruit flows
 

--- a/docs/BATTLE_SYSTEM_SPEC.md
+++ b/docs/BATTLE_SYSTEM_SPEC.md
@@ -142,7 +142,15 @@ interface CombatDuration {
 // Applied effect on a combatant (created from MaskEffect template).
 // Actual code uses a discriminated union; shown here simplified.
 type TargetEffect = {
-  type: 'DMG_MITIGATOR' | 'HEAL' | 'ATK_MULT' | 'AGGRO' | 'SPEED' | 'DEFENSE' | 'CONFUSION';
+  type:
+    | 'DMG_MITIGATOR'
+    | 'HEAL'
+    | 'ATK_MULT'
+    | 'AGGRO'
+    | 'SPEED'
+    | 'DEFENSE'
+    | 'ACCURACY_MULT'
+    | 'CONFUSION';
   multiplier?: number; // Effect strength (can be negative for debuffs); absent on CONFUSION
   durationRemaining: number; // Decrements each matching unit
   durationUnit: 'attack' | 'hit' | 'turn' | 'round';
@@ -211,6 +219,16 @@ When a mask is activated, it creates `TargetEffect` instances on the appropriate
 
 **Important:** Cooldown only starts decrementing AFTER all effects with `sourceId === combatant.id` have expired (durationRemaining === 0).
 
+### Hit Accuracy (ACCURACY_MULT)
+
+Attacks normally always connect (`BASE_HIT_CHANCE = 1`). Before damage is calculated, `rollAttackHits(attacker)` checks whether the swing lands:
+
+- `hitChance = BASE_HIT_CHANCE × product(active ACCURACY_MULT multipliers on attacker)`
+- Multipliers stack multiplicatively (e.g. two `0.5` debuffs → 25% hit chance)
+- On miss: no damage, no hit feedback, no target Hit/Defeat animation; attacker turn counters still decrement
+
+**Ruru (Mask of Night Vision):** `target: 'allEnemies'`. On activation at round start, every living enemy receives `ACCURACY_MULT` with `multiplier: 0.5` for 2 turns (duration decrements on each enemy's turn). Cooldown: 4 turns.
+
 ## State Persistence
 
 ### Ephemeral (Lost on Reload)
@@ -239,7 +257,8 @@ When a mask is activated, it creates `TargetEffect` instances on the appropriate
 ### Combat Utils (`combatUtils.ts`)
 
 - `queueCombatRound`: Orchestrates round execution
-- `triggerMaskPowers`: Handles mask power activation
+- `triggerMaskPowers`: Handles mask power activation (self, team, allEnemies)
+- `getAccuracyMultiplier` / `rollAttackHits`: Hit chance from ACCURACY_MULT debuffs
 - `calculateAtkDmg`: Computes damage with element effectiveness
 - `chooseTarget`: Implements targeting strategies
 - `generateCombatantStats`: Creates combatant instances from templates
@@ -251,11 +270,12 @@ When a mask is activated, it creates `TargetEffect` instances on the appropriate
 - ✅ Element effectiveness system
 - ✅ Battle strategies (Random, LowestHp, MostEffective)
 - ✅ Mask power activation
-- ✅ Mask power effect application (ATK_MULT, DMG_MITIGATOR, HEAL, AGGRO, SPEED)
+- ✅ Mask power effect application (ATK_MULT, DMG_MITIGATOR, HEAL, AGGRO, SPEED, ACCURACY_MULT)
 - ✅ Mask power duration tracking (all unit types)
 - ✅ Mask power cooldown tracking (all unit types)
 - ✅ Komau CONFUSION effect
+- ✅ Ruru ACCURACY_MULT (allEnemies blind, hit roll)
 - ✅ Reward distribution (EXP, loot, Krana)
 - ✅ Experience gain (persisted on Collect Rewards)
-- ❌ Advanced mask effects (ACCURACY_MULT for Ruru, Matatu immobilize)
+- ❌ Matatu immobilize (skip enemy turn)
 - ✅ Nuva mask powers (team-wide effects)

--- a/docs/COMBAT_TEST_COVERAGE.md
+++ b/docs/COMBAT_TEST_COVERAGE.md
@@ -107,7 +107,7 @@ _(All suggested next steps have been addressed by the fix above.)_
 | Kakama | SPEED (extra turn)        | round(1)  | turn(5)  | ✓ (triggerMaskPowers) |
 | Pakari | ATK_MULT (3x)             | attack(1) | turn(2)  | ✓                     |
 | Miru   | DMG_MITIGATOR (0, 2 hits) | hit(2)    | wave(1)  | ✓                     |
-| Ruru   | ACCURACY_MULT (0.5)       | turn(2)   | turn(4)  | ✗                     |
+| Ruru   | ACCURACY_MULT (0.5)       | turn(2)   | turn(4)  | ✓ (rollAttackHits)    |
 | Komau  | CONFUSION                 | turn(3)   | turn(4)  | ✓                     |
 | Rau    | ATK_MULT (1.5x, wave)     | wave(1)   | wave(2)  | ✓                     |
 | Matatu | Immobilize enemy          | wave(1)   | turn(2)  | ✗                     |
@@ -125,6 +125,7 @@ _(All suggested next steps have been addressed by the fix above.)_
 - `calculateAtkDmg` with ATK_MULT masks
 - `applyDamage` with DMG_MITIGATOR masks
 - `applyHealing` with HEAL masks
+- `getAccuracyMultiplier` / `rollAttackHits` with ACCURACY_MULT (Ruru)
 
 ### Masks covered
 
@@ -136,6 +137,7 @@ _(All suggested next steps have been addressed by the fix above.)_
 | Miru   | ✓       | Full immunity when active                                  |
 | Mahiki | ✓       | Full immunity when active                                  |
 | Kaukau | ✓       | 20% heal when active, no heal when inactive, cap at max HP |
+| Ruru   | ✓       | Accuracy multiplier stacking; hit/miss rolls at 0.5 debuff   |
 
 ### Gaps
 
@@ -196,6 +198,9 @@ _(All suggested next steps have been addressed by the fix above.)_
 | Miru (2 hit duration) provides mitigation for first 2 hits             | ✓         |
 | Mahiki (1 hit duration) provides mitigation for 1 hit then expires     | ✓         |
 | Huna (1 turn untargetable) makes enemy untargetable when active        | ✓         |
+| Ruru applies ACCURACY_MULT to every living enemy on activation         | ✓         |
+| Ruru blinded enemy misses their attack                                 | ✓         |
+| Ruru ACCURACY_MULT lasts exactly 2 enemy turns                         | ✓         |
 | Komau CONFUSION makes enemy attack their own team                      | ✓         |
 | Komau CONFUSION: confused enemy attacks itself when alone              | ✓         |
 | Kakama grants Pohatu two attacks in one round                          | ✓         |
@@ -221,6 +226,7 @@ _(All suggested next steps have been addressed by the fix above.)_
 | Mahiki | ✓       | Hit duration (1 hit)                                                          |
 | Huna   | ✓       | AGGRO untargetable                                                            |
 | Komau  | ✓       | CONFUSION debuff                                                              |
+| Ruru   | ✓       | allEnemies ACCURACY_MULT, miss on blind, 2-turn duration on enemy             |
 
 ### Gaps / Known issues
 
@@ -234,8 +240,8 @@ _(All suggested next steps have been addressed by the fix above.)_
 
 | Aspect                   | maskPowers | maskPowerCooldowns | battleSimulation         |
 | ------------------------ | ---------- | ------------------ | ------------------------ |
-| Masks tested             | 6 of 12    | N/A (wave only)    | 9 of 12                  |
-| Effect types tested      | 3 of 7     | -                  | -                        |
+| Masks tested             | 7 of 12    | N/A (wave only)    | 10 of 12                 |
+| Effect types tested      | 4 of 8     | -                  | -                        |
 | Duration units exercised | -          | 5 of 5 (all)       | round, attack, turn, hit |
 | Cooldown units exercised | -          | 2 of 2 (all)       | wave                     |
 | Full combat flow         | ✗          | ✗                  | ✓                        |
@@ -248,12 +254,14 @@ _(All suggested next steps have been addressed by the fix above.)_
 2. ~~**maskPowerCooldowns.spec.ts**: Consider exporting `decrementMaskPowerCounter` for unit tests, or add tests via battle simulation for turn/round/attack/hit.~~ ✓ Exported and tested for all unit types
 3. ~~**battleSimulation.spec.ts**: Add Akaku, Miru, Mahiki, Huna; add hit-based duration tests.~~ ✓ Implemented
 4. ~~**battleSimulation.spec.ts**: Fix multi-round post-advanceWave bug (Hau stays active in wave 2 when wave 1 rounds run first).~~ ✓ Fixed — duration reset on reactivation, all tests pass.
-5. **Unimplemented effects**: Ruru (ACCURACY_MULT), Matatu (immobilize) — tests can wait until implemented. Komau (CONFUSION) — ✓ Implemented.
+5. ~~**Ruru (ACCURACY_MULT)**: Implement effect + tests.~~ ✓ Implemented (`rollAttackHits`, `allEnemies` activation, battle simulation coverage).
+6. **Matatu (immobilize)**: Implement skip-turn effect and tests when combat support is added.
 
 ---
 
 ## Implementation Notes
 
+- **combatUtils.ts**: `rollAttackHits` runs before `calculateAtkDmg`; misses skip damage and target hit animations.
 - **combatUtils.ts**: Cooldown is correctly set from MASK_POWERS when duration expires; not decremented in same pass.
 - **combatUtils.ts**: Round-end decrements (mask power duration, debuffs) run as a dedicated final step after all actor turns, so they always execute regardless of turn order or early exits.
 - **combatUtils.ts**: Optional `getLatestState` callback allows round-end to read latest team/enemies and avoid stale closures.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates project documentation for the merged Ruru mask implementation and adjusts the main CI workflow so pull requests and pushes that only touch Markdown files do not run Test, E2E, Build, or Deploy.

## Documentation

### `docs/BATTLE_SYSTEM_SPEC.md`
- Add `ACCURACY_MULT` to the documented `TargetEffect` union
- New **Hit Accuracy (ACCURACY_MULT)** section (`rollAttackHits`, miss behavior, Ruru specifics)
- Mark Ruru as implemented; Matatu immobilize remains outstanding

### `docs/COMBAT_TEST_COVERAGE.md`
- Ruru marked implemented in mask and test coverage tables
- Updated cross-file summary counts and next steps (Matatu only)

### `ARCHITECTURE_ROADMAP.md`
- §4.1: Ruru implemented; Matatu is the remaining mask combat gap

## CI

### `.github/workflows/main.yml`
- **`Detect changes`** job diffs the PR/push against its base and sets `docs_only=true` when every changed file is `*.md`
- **`Docs only (CI skipped)`** job runs instead of the heavy pipeline for markdown-only diffs
- **Test & Lint**, **E2E**, **Build**, and **Deploy** are skipped when `docs_only=true`
- Mixed PRs (e.g. docs + code) still run the full pipeline

**Note:** This PR itself is not docs-only (it includes the workflow change), so the full CI suite will still run here. After merge, future README/docs-only PRs will skip the heavy jobs.

Skipped jobs count as successful for GitHub required checks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4432151-7955-4778-a03f-83f320ebcbdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4432151-7955-4778-a03f-83f320ebcbdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

