### PR TITLE
Document PWA update banner redesign and E2E coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,4 +23,5 @@ See `README.md` for the full list. The most common ones:
 - **Architecture rules**: Read `AGENT_GUIDELINES.md` before making code changes — it documents strict layer separation, state management patterns, and domain invariants.
 - **3D models**: GLB files in `public/` are loaded asynchronously via React Three Fiber. The 3D canvas uses a portal pattern (`#canvas-mount`).
 - **E2E snapshots**: Playwright visual regression tests produce platform-dependent screenshots. For deterministic results, use `yarn test:e2e:docker` (requires Docker). Running `yarn test:e2e` natively will likely produce snapshot mismatches.
+- **PWA banner in E2E**: `PWABadge` is forced visible via `setupGameState(page, state, { pwaBanner: 'needRefresh' | 'offlineReady' })` (sets `E2E_PWA_BANNER` in test mode). See `e2e/pwaUpdateBanner.spec.ts`.
 - **Environment variables**: No secrets or runtime env vars are required. Normal development and production builds work without any `.env` file. The only optional knob is **`VITE_TELEMETRY_URL`** at build time, which enables the optional anonymous telemetry pipeline (user consent still required); see `docs/TELEMETRY.md`.

--- a/ARCHITECTURE_ROADMAP.md
+++ b/ARCHITECTURE_ROADMAP.md
@@ -18,8 +18,9 @@ This document identifies technical debt, inconsistencies, and architectural impr
 
 - Successful recruitment shows `RecruitmentCelebration` (animated modal with 3D character reveal and element-colored particles).
 - Insufficient protodermis disables the recruit button (`canRecruit` guard); `recruitMatoran` returns the prior state without side effects.
+- PWA update and offline-ready prompts use `PWABadge` (`src/components/CacheManagement/PWABadge.tsx`): a dark-themed bottom banner over the nav bar (Orbitron title, app button styles, slide-up motion). Replaces the previous default Vite PWA white top-right toast. Visual regression coverage in `e2e/pwaUpdateBanner.spec.ts`.
 
-**Remaining gap (optional polish):** There is still no shared toast/activity-log system for other transient feedback (e.g. PWA update badge is the only toast-like UI). Consider a unified non-blocking feedback component if more surfaces need it.
+**Remaining gap (optional polish):** There is still no shared toast/activity-log system for _other_ transient feedback beyond recruitment celebration and the PWA banner. Consider a unified non-blocking feedback component if more surfaces need it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,17 @@ The game automatically saves to localStorage:
 - Save data includes versioning for compatibility
 - You can reset your game data from the Settings page
 
+## 📲 PWA & app updates
+
+The app is installable as a progressive web app (Vite PWA plugin + Workbox). Assets and GLBs are cached for offline play.
+
+When a new deployment is available, `PWABadge` (`src/components/CacheManagement/PWABadge.tsx`) shows a **bottom banner** over the navigation bar:
+
+- **Update available** — Reload applies the new service worker; Later dismisses until the next detection
+- **Ready for offline play** — Shown after the service worker is first activated; Got it dismisses
+
+The banner uses the same dark glass styling, Orbitron headings, and button classes as the rest of the UI. Playwright visual tests force banner visibility via `E2E_PWA_BANNER` in test mode — see `e2e/pwaUpdateBanner.spec.ts` and `e2e/README.md`.
+
 ## 🐛 Debug & Performance
 
 - **Quest Debug mode** (Settings): Shortens quest durations to 1 second for testing
@@ -236,7 +247,7 @@ The game automatically saves to localStorage:
 | [AGENT_GUIDELINES.md](AGENT_GUIDELINES.md)         | Architecture, layers, and invariants for contributors and automation       |
 | [AGENTS.md](AGENTS.md)                             | Cursor Cloud / agent quick reference (commands and caveats)                |
 | [docs/TELEMETRY.md](docs/TELEMETRY.md)             | Optional build-time telemetry (`VITE_TELEMETRY_URL`) and privacy behaviour |
-| [e2e/README.md](e2e/README.md)                     | Playwright E2E tests and snapshot workflow                                 |
+| [e2e/README.md](e2e/README.md)                     | Playwright E2E tests and snapshot workflow (incl. PWA banner overrides)    |
 | [ARCHITECTURE_ROADMAP.md](ARCHITECTURE_ROADMAP.md) | Technical debt and improvement backlog (updated as items land or change)   |
 | [docs/UI_UX_STRATEGY.md](docs/UI_UX_STRATEGY.md) | Portrait-first UI/UX direction and phased 3D expansion plan                |
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -95,13 +95,14 @@ All 3D character models in this app have animations (idle animations, flavor ani
 
 - **Test Mode Utilities** (`src/utils/testMode.ts`):
   - `isTestMode()` - Detects if `localStorage.getItem('TEST_MODE') === 'true'`
+  - `getE2ePwaBannerState()` - Reads `E2E_PWA_BANNER` (`needRefresh` \| `offlineReady`) when test mode is on; used by `PWABadge` for deterministic banner screenshots
   - `getAnimationTimeScale()` - Returns 0 in test mode, 1 otherwise
   - `shouldDisableAnimations()` - Returns true in test mode
   - `setupAnimationForTestMode(action)` - Forces animation to frame 0 and pauses it in test mode
 
 - **Test Helpers** (`e2e/helpers.ts`):
-  - `enableTestMode(page)` - Sets localStorage flag before page load
-  - `setupGameState(page, state)` - Sets game state and automatically enables test mode
+  - `enableTestMode(page, options?)` - Sets localStorage flag before page load; optional `{ pwaBanner: 'needRefresh' | 'offlineReady' }`
+  - `setupGameState(page, state, options?)` - Sets game state and automatically enables test mode; optional `{ pwaBanner }` as above
   - `goto(page, path)` - Navigate to a path (test mode persists via localStorage)
 
 - **Model Integration**: All character models (Toa, Matoran, Bohrok) call `setupAnimationForTestMode()` on their idle animations to ensure they're paused at frame 0
@@ -132,6 +133,12 @@ test('should render with custom state', async ({ page }) => {
 });
 ```
 
+### PWA update banner
+
+The PWA update prompt normally appears only when the service worker detects a new build. For visual regression, pass `{ pwaBanner: 'needRefresh' }` or `{ pwaBanner: 'offlineReady' }` to `setupGameState` (or `enableTestMode`). This sets `localStorage.E2E_PWA_BANNER`, which `PWABadge` reads in test mode.
+
+See `e2e/pwaUpdateBanner.spec.ts` for banner element snapshots at desktop, mobile portrait, and mobile landscape, plus one full-page mobile portrait shot over the character inventory and nav.
+
 ## Visual Regression Tolerance
 
 Different test scenarios have different tolerance levels for pixel differences:
@@ -153,6 +160,7 @@ Different test scenarios have different tolerance levels for pixel differences:
 - `battle/flow.spec.ts` - Battle flow (prep, combat, victory/defeat)
 - `battle/type-effectiveness.spec.ts` - Type effectiveness page
 - `settings.spec.ts` - Settings page (about, credits, disclaimers, game reset, debug mode, shadows)
+- `pwaUpdateBanner.spec.ts` - PWA update / offline-ready bottom banner over navigation
 
 ## CI/CD Integration
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documentation follow-up for the merged PWA update notification work (#329).

## Changes

- **README.md** — New "PWA & app updates" section describing the bottom banner, its two states, styling, and how to test it
- **ARCHITECTURE_ROADMAP.md** — §2.1 updated to record `PWABadge` as implemented feedback UI; clarifies remaining toast gap applies to other surfaces
- **e2e/README.md** — Documents `E2E_PWA_BANNER` / `getE2ePwaBannerState()`, `setupGameState` / `enableTestMode` `pwaBanner` option, and `pwaUpdateBanner.spec.ts`
- **AGENTS.md** — Agent caveat for forcing the PWA banner in Playwright tests

## Testing

Docs only — no code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01541f07-5377-4091-affb-113b47247e4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01541f07-5377-4091-affb-113b47247e4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

